### PR TITLE
Make code quality improvements

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -1,7 +1,7 @@
 {
   "all": true,
   "include": ["out/**"],
-  "exclude": ["**/node_modules/**", "out/test/"],
+  "exclude": ["**/node_modules/**", "**/test/**", "**/config/**"],
   "reporter": ["lcov", "text"],
   "lines": 5
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,5 +42,5 @@
       }
     ]
   },
-  "ignorePatterns": ["out", "dist", "**/*.d.ts"]
+  "ignorePatterns": ["out", "dist", "**/*.d.ts", "**/*.js"]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,13 @@
     "plugin:import/typescript"
   ],
   "rules": {
-    "@typescript-eslint/naming-convention": "warn",
+    "@typescript-eslint/naming-convention": [
+      "warn",
+      {
+        "selector": "typeLike",
+        "format": ["PascalCase", "camelCase"]
+      }
+    ],
     "@typescript-eslint/semi": "warn",
     "import/no-unresolved": [
       "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,0 @@
-# Change Log
-
-## [Unreleased]
-
-- Initial release

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ You certainly need [Node](https://nodejs.org/en/) 16.x. Development is done with
 ## Running Tests
 1. Run `npm test` in the root directory
 
+## Development
+
+To change development environment settings, edit the `extensionConfig` in `webpack.config.js` and change `mode` to one of the following:
+- `development`
+- `staging`
+- `production`
+
+Each mode currently controls where each environment points to. For example, `development` points to `https://addons-dev.allizom.org` and `production` points to `https://addons.mozilla.org`.
+
 ---
 
 

--- a/src/amo/commands/fetch.ts
+++ b/src/amo/commands/fetch.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as vscode from "vscode";
 
-import { AddonInfoResponse } from "../interfaces";
+import { addonInfoResponse } from "../types";
 import { downloadAddon } from "../utils/addonDownload";
 import { extractAddon } from "../utils/addonExtract";
 import { getAddonInfo } from "../utils/addonInfo";
@@ -27,7 +27,7 @@ export const downloadAndExtract = vscode.commands.registerCommand(
     }
 
     // Retrieve metadata
-    const json: AddonInfoResponse = await getAddonInfo(input);
+    const json: addonInfoResponse = await getAddonInfo(input);
     console.log(json);
     if (!json) {
       vscode.window.showErrorMessage("No addon found");
@@ -38,7 +38,7 @@ export const downloadAndExtract = vscode.commands.registerCommand(
     const addonVersion = versionInfo.version;
     const reviewUrl = json.review_url;
     console.log(reviewUrl);
-    const addonGUID = json.guid[0] === "{" ? json.guid.slice(1, -1) : json.guid;
+    const addonGUID = json.guid;
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
     const compressedFilePath =
       workspaceFolder + "/" + addonGUID + "_" + addonVersion + ".xpi";

--- a/src/amo/commands/updateTaskbar.ts
+++ b/src/amo/commands/updateTaskbar.ts
@@ -25,11 +25,9 @@ export async function updateTaskbar() {
   if (!rootFolder) {
     return;
   }
-  const relativePath = filePath.replace(rootFolder, "");
-  const pathParts = relativePath.split(path.sep);
-  const guid = pathParts[1];
-  const version = pathParts[2];
 
+  const relativePath = filePath.replace(rootFolder, "");
+  const [guid, version] = relativePath.split(path.sep).splice(-2);
   if (!guid || !version) {
     return;
   }

--- a/src/amo/commands/updateTaskbar.ts
+++ b/src/amo/commands/updateTaskbar.ts
@@ -27,34 +27,28 @@ export async function updateTaskbar() {
   }
 
   const relativePath = filePath.replace(rootFolder, "");
-  const [guid, version] = relativePath.split(path.sep).splice(-2);
+  const [guid, version] = relativePath.split(path.sep).splice(1);
   if (!guid || !version) {
     return;
   }
 
   const reviewUrl = `${constants.reviewBaseURL}${guid}`;
-  try {
-    const response = await Promise.race([
-      fetch(reviewUrl),
-      new Promise<Response>((_, reject) =>
-        setTimeout(() => reject(new Error("Request timed out")), 2000)
-      ) as Promise<Response>,
-    ]);
 
-    if (response.status === 404) {
-      // not a review page
-      return;
-    } else if (response.status === 403) {
-      // not authed
-      return;
-    } else if (response.status !== 200) {
-      // other errors
-      return;
+  const AbortController =
+    globalThis.AbortController || (await import("abort-controller"));
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 2000);
+
+  try {
+    const response = await fetch(reviewUrl, { signal: controller.signal });
+    if (response.status !== 200) {
+      throw new Error("Request failed. Status: " + response.status);
     }
   } catch (error) {
-    // timed out
     console.error(error);
     return;
+  } finally {
+    clearTimeout(timeout);
   }
 
   statusBarItem.text = `${guid} ${version}`;

--- a/src/amo/types.ts
+++ b/src/amo/types.ts
@@ -1,4 +1,5 @@
-export interface AddonInfoResponse {
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type addonInfoResponse = {
   slug: string;
   name: {
     [key: string]: string;
@@ -15,9 +16,10 @@ export interface AddonInfoResponse {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   review_url: string;
   guid: string;
-}
+};
 
-export interface AddonVersion {
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type addonVersion = {
   map(
     arg0: (version: any) => any
   ): readonly string[] | Thenable<readonly string[]>;
@@ -26,4 +28,11 @@ export interface AddonVersion {
   file: {
     id: string;
   };
-}
+};
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export type configConstants = {
+  apiBaseURL: string;
+  reviewBaseURL: string;
+  downloadBaseURL: string;
+};

--- a/src/amo/types.ts
+++ b/src/amo/types.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export type addonInfoResponse = {
   slug: string;
   name: {
@@ -18,7 +17,6 @@ export type addonInfoResponse = {
   guid: string;
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export type addonVersion = {
   map(
     arg0: (version: any) => any
@@ -30,7 +28,6 @@ export type addonVersion = {
   };
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export type configConstants = {
   apiBaseURL: string;
   reviewBaseURL: string;

--- a/src/amo/utils/addonDownload.ts
+++ b/src/amo/utils/addonDownload.ts
@@ -2,8 +2,10 @@ import * as fs from "fs";
 import fetch from "node-fetch";
 import * as vscode from "vscode";
 
-export async function downloadAddon(id: string, path: string) {
-  const url = `https://addons.mozilla.org/firefox/downloads/file/${id}`;
+import constants from "../../config/config";
+
+export async function downloadAddon(fileId: string, path: string) {
+  const url = `${constants.downloadBaseURL}${fileId}`;
   const response = await fetch(url);
 
   if (response.ok) {

--- a/src/amo/utils/addonExtract.ts
+++ b/src/amo/utils/addonExtract.ts
@@ -5,8 +5,6 @@ import * as vscode from "vscode";
 function dirExistsOrMake(dir: string) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir);
-    return false;
-  } else {
     return true;
   }
 }
@@ -18,7 +16,7 @@ export async function extractAddon(
 ) {
   dirExistsOrMake(addonFolderPath);
 
-  if (dirExistsOrMake(addonVersionFolderPath)) {
+  if (!dirExistsOrMake(addonVersionFolderPath)) {
     const choice = await vscode.window.showQuickPick(["Yes", "No"], {
       placeHolder: "Addon already exists. Overwrite?",
     });

--- a/src/amo/utils/addonInfo.ts
+++ b/src/amo/utils/addonInfo.ts
@@ -1,18 +1,13 @@
 import fetch from "node-fetch";
 
+import constants from "../../config/config";
+
 export async function getAddonInfo(input: string) {
-  if (input.includes("/")) {
-    // only for links
-    const slug = input.split("addon/")[1].split("/")[0];
-    const url = `https://addons.mozilla.org/api/v5/addons/addon/${slug}`;
-    const response = await fetch(url);
-    const json = await response.json();
-    return json;
-  } else {
-    // other identifiers work here
-    const url = `https://addons.mozilla.org/api/v5/addons/addon/${input}`;
-    const response = await fetch(url);
-    const json = await response.json();
-    return json;
-  }
+  const slug: string = input.includes("/")
+    ? input.split("addon/")[1].split("/")[0]
+    : input;
+  const url = `${constants.apiBaseURL}${slug}`;
+  const response = await fetch(url);
+  const json = await response.json();
+  return json;
 }

--- a/src/amo/utils/addonVersions.ts
+++ b/src/amo/utils/addonVersions.ts
@@ -1,40 +1,29 @@
 import fetch from "node-fetch";
 import * as vscode from "vscode";
 
-import { AddonVersion } from "../interfaces";
+import constants from "../../config/config";
+import { addonVersion } from "../types";
 
-export async function getAddonVersions(
-  input: string | undefined,
-  next?: string
-) {
+export async function getAddonVersions(input: string, next?: string) {
   if (next) {
     const url = next;
     const response = await fetch(url);
     const json = await response.json();
     return json;
   }
-  if (!input) {
-    return;
-  } else if (input.includes("/")) {
-    // only for links
-    const slug = input.split("addon/")[1].split("/")[0];
-    const url = `https://addons.mozilla.org/api/v5/addons/addon/${slug}/versions/`;
-    const response = await fetch(url);
-    const json = await response.json();
-    return json;
-  } else {
-    // other identifiers work here
-    const url = `https://addons.mozilla.org/api/v5/addons/addon/${input}/versions/`;
-    const response = await fetch(url);
-    const json = await response.json();
-    return json;
-  }
+  const slug: string = input.includes("/")
+    ? input.split("addon/")[1].split("/")[0]
+    : input;
+  const url = `${constants.apiBaseURL}${slug}/versions/`;
+  const response = await fetch(url);
+  const json = await response.json();
+  return json;
 }
 
 export async function getVersionChoice(
   input: string
 ): Promise<{ fileID: string; version: string } | undefined> {
-  const versions: AddonVersion[] = [];
+  const versions: addonVersion[] = [];
   let next: string | undefined = undefined;
   let init = true;
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,0 +1,14 @@
+import { DEV, STAGE, PROD } from "./constants";
+import { configConstants } from "../amo/types";
+
+const environment = process.env.NODE_ENV;
+
+let constants: configConstants;
+if (environment === "development") {
+  constants = DEV;
+} else if (environment === "staging") {
+  constants = STAGE;
+} else {
+  constants = PROD;
+}
+export default constants;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,0 +1,18 @@
+export const DEV = {
+  apiBaseURL: "https://addons-dev.allizom.org/api/v5/",
+  reviewBaseURL:
+    "https://reviewers.addons-dev.allizom.org/en-US/reviewers/review/",
+  downloadBaseURL: "https://addons-dev.allizom.org/firefox/downloads/file/",
+};
+
+export const STAGE = {
+  apiBaseURL: "https://addons.allizom.org/api/v5/",
+  reviewBaseURL: "https://reviewers.addons.allizom.org/en-US/reviewers/review/",
+  downloadBaseURL: "https://addons.allizom.org/firefox/downloads/file/",
+};
+
+export const PROD = {
+  apiBaseURL: "https://addons.mozilla.org/api/v5/",
+  reviewBaseURL: "https://reviewers.addons.mozilla.org/en-US/reviewers/review/",
+  downloadBaseURL: "https://addons.mozilla.org/firefox/downloads/file/",
+};

--- a/src/test/suite/utils/AddonDownload.test.ts
+++ b/src/test/suite/utils/AddonDownload.test.ts
@@ -6,6 +6,7 @@ import path = require("path");
 import * as sinon from "sinon";
 
 import { downloadAddon } from "../../../amo/utils/addonDownload";
+import constants from "../../../config/config";
 
 describe("addonDownload.ts", async () => {
   afterEach(() => {
@@ -40,11 +41,8 @@ describe("addonDownload.ts", async () => {
     await downloadAddon(addonId, downloadedFilePath);
 
     expect(stub.calledOnce).to.be.true;
-    expect(
-      stub.calledWith(
-        `https://addons.mozilla.org/firefox/downloads/file/${addonId}`
-      )
-    ).to.be.true;
+    expect(stub.calledWith(`${constants.downloadBaseURL}${addonId}`)).to.be
+      .true;
 
     // wait for file to be written (there should be a better way to do this)
     await new Promise((resolve) => setTimeout(resolve, 500));
@@ -79,11 +77,8 @@ describe("addonDownload.ts", async () => {
 
     await downloadAddon(addonId, downloadedFilePath);
     expect(stub.calledOnce).to.be.true;
-    expect(
-      stub.calledWith(
-        `https://addons.mozilla.org/firefox/downloads/file/${addonId}`
-      )
-    ).to.be.true;
+    expect(stub.calledWith(`${constants.downloadBaseURL}${addonId}`)).to.be
+      .true;
 
     await new Promise((resolve) => setTimeout(resolve, 500));
     expect(fs.existsSync(downloadedFilePath)).to.be.false;

--- a/src/test/suite/utils/AddonExtract.test.ts
+++ b/src/test/suite/utils/AddonExtract.test.ts
@@ -29,19 +29,15 @@ describe("AddonExtract.ts", async () => {
     // extract xpi
     const addonGUID = "test-addon";
     const addonVersion = "1.0.0";
-    const extractedworkspaceFolder = path.resolve(
-      workspaceFolder,
-      "test-addon"
-    );
+    const extractedworkspaceFolder = path.resolve(workspaceFolder, addonGUID);
     const extractedVersionFolder = path.resolve(
       extractedworkspaceFolder,
       addonVersion
     );
     await extractAddon(
       compressedFilePath,
-      workspaceFolder,
-      addonGUID,
-      addonVersion
+      extractedworkspaceFolder,
+      extractedVersionFolder
     );
 
     expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;

--- a/src/test/suite/utils/AddonInfo.test.ts
+++ b/src/test/suite/utils/AddonInfo.test.ts
@@ -3,15 +3,16 @@ import { afterEach, describe, it } from "mocha";
 import * as fetch from "node-fetch";
 import * as sinon from "sinon";
 
-import { AddonInfoResponse } from "../../../amo/interfaces";
+import { addonInfoResponse } from "../../../amo/types";
 import { getAddonInfo } from "../../../amo/utils/addonInfo";
+import constants from "../../../config/config";
 
 describe("AddonInfo.ts", () => {
   afterEach(() => {
     sinon.restore();
   });
 
-  const expected: AddonInfoResponse = {
+  const expected: addonInfoResponse = {
     slug: "test-addon",
     name: {
       en: "Test addon",
@@ -30,7 +31,7 @@ describe("AddonInfo.ts", () => {
     guid: "gee you eye dee",
   };
 
-  it("should return a json object of type AddonInfoResponse if input is a slug", async () => {
+  it("should return a json object of type addonInfoResponse if input is a slug", async () => {
     const input = "test-addon";
     const stub = sinon.stub();
     stub.resolves({
@@ -41,12 +42,10 @@ describe("AddonInfo.ts", () => {
     const actual = await getAddonInfo(input);
     expect(actual).to.deep.equal(expected);
     expect(stub.calledOnce).to.be.true;
-    expect(
-      stub.calledWith(`https://addons.mozilla.org/api/v5/addons/addon/${input}`)
-    ).to.be.true;
+    expect(stub.calledWith(`${constants.apiBaseURL}${input}`)).to.be.true;
   });
 
-  it("should return a json object of type AddonInfoResponse if input is an id", async () => {
+  it("should return a json object of type addonInfoResponse if input is an id", async () => {
     const input = "123456";
     const stub = sinon.stub();
     stub.resolves({
@@ -57,12 +56,10 @@ describe("AddonInfo.ts", () => {
     const actual = await getAddonInfo(input);
     expect(actual).to.deep.equal(expected);
     expect(stub.calledOnce).to.be.true;
-    expect(
-      stub.calledWith(`https://addons.mozilla.org/api/v5/addons/addon/${input}`)
-    ).to.be.true;
+    expect(stub.calledWith(`${constants.apiBaseURL}${input}`)).to.be.true;
   });
 
-  it("should return a json object of type AddonInfoResponse if input is a url", async () => {
+  it("should return a json object of type addonInfoResponse if input is a url", async () => {
     const input = "https://addons.mozilla.org/en-US/firefox/addon/test-addon";
     const stub = sinon.stub();
     stub.resolves({
@@ -73,11 +70,8 @@ describe("AddonInfo.ts", () => {
     const actual = await getAddonInfo(input);
     expect(actual).to.deep.equal(expected);
     expect(stub.calledOnce).to.be.true;
-    expect(
-      stub.calledWith(
-        `https://addons.mozilla.org/api/v5/addons/addon/${expected.slug}`
-      )
-    ).to.be.true;
+    expect(stub.calledWith(`${constants.apiBaseURL}${expected.slug}`)).to.be
+      .true;
   });
 
   it("should throw an error if the response is not ok", async () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,10 +7,10 @@ const path = require('path');
 //@ts-check
 /** @typedef {import('webpack').Configuration} WebpackConfig **/
 
-/** @type WebpackConfig */
+/** @type WebpackConfig & { mode?: 'staging' | 'none' | 'development' | 'production' }*/
 const extensionConfig = {
   target: 'node', // VS Code extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
-	mode: 'none', // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
+	mode: 'development', // can be 'staging', 'none', 'development' or 'production'. 'none' changes to 'production' when packaging
 
   entry: './src/amo/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
   output: {


### PR DESCRIPTION
Fixes some of #2 and #3 

Have not
- Remade folder structure
- Better error handling
- Cached review url links  

In terms of cached review links, we actually have the review url stored in the `addonInfoResponse` type, so caching can completely do away with current implementation in `updateTaskbar.ts`. Auth can be handled when fetching addons (to show non-public versions) instead of the review page item. 