### PR TITLE
Add env variables for development modes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,17 +1,51 @@
 {
 	"version": "0.2.0",
 	"configurations": [
-		{
-			"name": "Run Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
-			],
-			"outFiles": [
-				"${workspaceFolder}/dist/**/*.js"
-			],
-			"preLaunchTask": "npm: compile"
+	  {
+		"name": "Run Assay (Development)",
+		"type": "extensionHost",
+		"request": "launch",
+		"args": [
+		  "--extensionDevelopmentPath=${workspaceFolder}"
+		],
+		"outFiles": [
+		  "${workspaceFolder}/dist/**/*.js"
+		],
+		"preLaunchTask": "npm: compile:dev",
+		"env": {
+		  "NODE_ENV": "development"
 		}
+	  },
+	  {
+		"name": "Run Assay (Staging)",
+		"type": "extensionHost",
+		"request": "launch",
+		"args": [
+		  "--extensionDevelopmentPath=${workspaceFolder}"
+		],
+		"outFiles": [
+		  "${workspaceFolder}/dist/**/*.js"
+		],
+		"preLaunchTask": "npm: compile:stage",
+		"env": {
+		  "NODE_ENV": "staging"
+		}
+	  },
+	  {
+		"name": "Run Assay (Production)",
+		"type": "extensionHost",
+		"request": "launch",
+		"args": [
+		  "--extensionDevelopmentPath=${workspaceFolder}"
+		],
+		"outFiles": [
+		  "${workspaceFolder}/dist/**/*.js"
+		],
+		"preLaunchTask": "npm: compile:prod",
+		"env": {
+		  "NODE_ENV": "production"
+		}
+	  }
 	]
-}
+  }
+  

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,51 +1,38 @@
 {
-	"version": "0.2.0",
-	"configurations": [
-	  {
-		"name": "Run Assay (Development)",
-		"type": "extensionHost",
-		"request": "launch",
-		"args": [
-		  "--extensionDevelopmentPath=${workspaceFolder}"
-		],
-		"outFiles": [
-		  "${workspaceFolder}/dist/**/*.js"
-		],
-		"preLaunchTask": "npm: compile:dev",
-		"env": {
-		  "NODE_ENV": "development"
-		}
-	  },
-	  {
-		"name": "Run Assay (Staging)",
-		"type": "extensionHost",
-		"request": "launch",
-		"args": [
-		  "--extensionDevelopmentPath=${workspaceFolder}"
-		],
-		"outFiles": [
-		  "${workspaceFolder}/dist/**/*.js"
-		],
-		"preLaunchTask": "npm: compile:stage",
-		"env": {
-		  "NODE_ENV": "staging"
-		}
-	  },
-	  {
-		"name": "Run Assay (Production)",
-		"type": "extensionHost",
-		"request": "launch",
-		"args": [
-		  "--extensionDevelopmentPath=${workspaceFolder}"
-		],
-		"outFiles": [
-		  "${workspaceFolder}/dist/**/*.js"
-		],
-		"preLaunchTask": "npm: compile:prod",
-		"env": {
-		  "NODE_ENV": "production"
-		}
-	  }
-	]
-  }
-  
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Assay (Development)",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "preLaunchTask": "npm: compile:dev",
+      "env": {
+        "NODE_ENV": "development"
+      }
+    },
+    {
+      "name": "Run Assay (Staging)",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "preLaunchTask": "npm: compile:stage",
+      "env": {
+        "NODE_ENV": "staging"
+      }
+    },
+    {
+      "name": "Run Assay (Production)",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "preLaunchTask": "npm: compile:prod",
+      "env": {
+        "NODE_ENV": "production"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -28,20 +28,21 @@ You certainly need [Node](https://nodejs.org/en/) 16.x. Development is done with
 
 ## Running the Extension
 1. Navigate to the debug view in the sidebar of VSCode
-2. Select `Run Extension` from the dropdown menu
-3. Click the green play button to start the extension
+2. From the dropdown menu beside the green play button, select one of the following options:
+    - `Run Assay (Development)`
+    - `Run Assay (Staging)`
+    - `Run Assay (Production)`
+3. Click the green play button to run the extension
 
-## Running Tests
-1. Run `npm test` in the root directory
+Each of these options will run the extension with different constants defined in `src/config/constants.ts`.
 
-## Development
+## Testing the Extension
+- Run the following commands to test the extension with the different constants defined in `src/config/constants.ts`:
+    - `npm run test:dev`
+    - `npm run test:stage`
+    - `npm run test:prod`
 
-To change development environment settings, edit the `extensionConfig` in `webpack.config.js` and change `mode` to one of the following:
-- `development`
-- `staging`
-- `production`
-
-Each mode currently controls where each environment points to. For example, `development` points to `https://addons-dev.allizom.org` and `production` points to `https://addons.mozilla.org`.
+###### *Note: Any command not configured to run with a specific environment variable will run with the development constants.*
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@vscode/test-electron": "^2.3.0",
         "c8": "^7.14.0",
         "chai": "^4.3.7",
+        "cross-env": "^7.0.3",
         "eslint": "^8.39.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-import-resolver-node": "^0.3.7",
@@ -1633,6 +1634,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,14 @@
     "lint": "eslint src --ext ts --fix",
     "test": "c8 --check-coverage node ./out/test/runTest.js",
     "prettier": "prettier --write \"src/**/*.ts\"",
-    "format": "npm run prettier && npm run lint"
+    "format": "npm run prettier && npm run lint",
+    "test:dev": "cross-env NODE_ENV=development npm run test",
+    "test:prod": "cross-env NODE_ENV=production npm run test",
+    "test:stage": "cross-env NODE_ENV=staging npm run test",
+    "test-all": "npm run test-dev && npm run test-prod && npm run test-stage",
+    "compile:dev": "cross-env NODE_ENV=development npm run compile",
+    "compile:prod": "cross-env NODE_ENV=production npm run compile",
+    "compile:stage": "cross-env NODE_ENV=staging npm run compile"
   },
   "devDependencies": {
     "@types/chai": "^4.3.5",
@@ -53,6 +60,7 @@
     "@vscode/test-electron": "^2.3.0",
     "c8": "^7.14.0",
     "chai": "^4.3.7",
+    "cross-env": "^7.0.3",
     "eslint": "^8.39.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-import-resolver-node": "^0.3.7",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -4,11 +4,11 @@ import { configConstants } from "../amo/types";
 const environment = process.env.NODE_ENV;
 
 let constants: configConstants;
-if (environment === "development") {
-  constants = DEV;
+if (environment === "production") {
+  constants = PROD;
 } else if (environment === "staging") {
   constants = STAGE;
 } else {
-  constants = PROD;
+  constants = DEV;
 }
 export default constants;

--- a/src/test/suite/utils/AddonDownload.test.ts
+++ b/src/test/suite/utils/AddonDownload.test.ts
@@ -14,7 +14,6 @@ describe("addonDownload.ts", async () => {
   });
 
   it("should download the xpi of the addon", async () => {
-    console.log(constants.downloadBaseURL + "\n\n\n");
     // mock response
     const fakeResponse = {
       ok: true,

--- a/src/test/suite/utils/AddonDownload.test.ts
+++ b/src/test/suite/utils/AddonDownload.test.ts
@@ -14,6 +14,7 @@ describe("addonDownload.ts", async () => {
   });
 
   it("should download the xpi of the addon", async () => {
+    console.log(constants.downloadBaseURL + "\n\n\n");
     // mock response
     const fakeResponse = {
       ok: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ const path = require('path');
 /** @type WebpackConfig & { mode?: 'staging' | 'none' | 'development' | 'production' }*/
 const extensionConfig = {
   target: 'node', // VS Code extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
-	mode: 'none', // can be 'staging', 'none', 'development' or 'production'. 'none' changes to 'production' when packaging
+	mode: 'none', // can be 'staging', 'none', 'development' or 'production'. 'none' defaults to 'development'
                 // keep this at none during development, this will override the NODE_ENV used by the debugger
 
   entry: './src/amo/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,8 @@ const path = require('path');
 /** @type WebpackConfig & { mode?: 'staging' | 'none' | 'development' | 'production' }*/
 const extensionConfig = {
   target: 'node', // VS Code extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
-	mode: 'development', // can be 'staging', 'none', 'development' or 'production'. 'none' changes to 'production' when packaging
+	mode: 'none', // can be 'staging', 'none', 'development' or 'production'. 'none' changes to 'production' when packaging
+                // keep this at none during development, this will override the NODE_ENV used by the debugger
 
   entry: './src/amo/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
   output: {


### PR DESCRIPTION
View the readme for instructions on how to use env variables. This PR is to allow the changing of environment during development. Currently, only urls are changed do dev, stage, prod depending on the NODE_ENV variable.