### PR TITLE
Update error handling with tests

### DIFF
--- a/src/amo/commands/getAddon.ts
+++ b/src/amo/commands/getAddon.ts
@@ -1,82 +1,53 @@
 import * as fs from "fs";
 import * as vscode from "vscode";
 
-import { addonInfoResponse } from "../types";
 import { downloadAddon } from "../utils/addonDownload";
 import { extractAddon } from "../utils/addonExtract";
 import { getAddonInfo } from "../utils/addonInfo";
 import { getVersionChoice } from "../utils/addonVersions";
 
-export async function downloadAndExtract() {
-  const input: string | undefined = await vscode.window.showInputBox({
-    prompt: "Enter Addon Slug, GUID, or URL",
-    title: "Assay",
+export function getInput(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    vscode.window
+      .showInputBox({
+        prompt: "Enter Addon Slug, GUID, or URL",
+        title: "Assay",
+      })
+      .then((input) => {
+        if (!input) {
+          reject(new Error("No input provided"));
+        } else {
+          resolve(input);
+        }
+      });
   });
+}
 
-  if (!input) {
-    return;
-  }
+export async function downloadAndExtract() {
+  try {
+    const input = await getInput();
 
-  // Retrieve version
-  const versionInfo = await getVersionChoice(input);
-  if (!versionInfo) {
-    return;
-  }
+    const versionInfo = await getVersionChoice(input);
+    const addonFileId = versionInfo.fileID;
+    const addonVersion = versionInfo.version;
 
-  // Retrieve metadata
-  const json: addonInfoResponse = await getAddonInfo(input);
-  if (!json) {
-    vscode.window.showErrorMessage("Cannot retrieve addon metadata");
-    return;
-  }
+    const json = await getAddonInfo(input);
+    const addonGUID = json.guid;
 
-  const addonFileId = versionInfo.fileID;
-  const addonVersion = versionInfo.version;
-  const addonGUID = json.guid;
-  const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
-  const compressedFilePath =
-    workspaceFolder + "/" + addonGUID + "_" + addonVersion + ".xpi";
-
-  if (!workspaceFolder) {
-    vscode.window.showErrorMessage("No workspace folder found");
-    return;
-  }
-
-  // Download
-  await vscode.window.withProgress(
-    { title: "Assay", location: vscode.ProgressLocation.Notification },
-    async function (progress) {
-      progress.report({
-        message: "Downloading " + input,
-      });
-
-      await downloadAddon(addonFileId, compressedFilePath);
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+    if (!workspaceFolder) {
+      vscode.window.showErrorMessage("No workspace folder found");
+      throw new Error("No workspace folder found");
     }
-  );
+    const compressedFilePath = `${workspaceFolder}/${addonGUID}_${addonVersion}.zip`;
 
-  if (!fs.existsSync(compressedFilePath)) {
-    vscode.window.showErrorMessage("Cannot download addon");
-    return;
-  }
-
-  // Extract
-  vscode.window.withProgress(
-    { title: "Assay", location: vscode.ProgressLocation.Notification },
-    async function (progress) {
-      progress.report({
-        message: "Extracting",
-      });
-
-      await extractAddon(
-        compressedFilePath,
-        `${workspaceFolder}/${addonGUID}`,
-        `${workspaceFolder}/${addonGUID}/${addonVersion}`
-      );
-    }
-  );
-
-  if (!fs.existsSync(`${workspaceFolder}/${addonGUID}/${addonVersion}`)) {
-    vscode.window.showErrorMessage("Extraction failed");
-    return;
+    await downloadAddon(addonFileId, compressedFilePath);
+    await extractAddon(
+      compressedFilePath,
+      `${workspaceFolder}/${addonGUID}`,
+      `${workspaceFolder}/${addonGUID}/${addonVersion}`
+    );
+  } catch (error) {
+    console.error(error);
   }
 }

--- a/src/amo/utils/addonDownload.ts
+++ b/src/amo/utils/addonDownload.ts
@@ -4,22 +4,21 @@ import * as vscode from "vscode";
 
 import constants from "../../config/config";
 
-export async function downloadAddon(
-  fileId: string,
-  path: string
-): Promise<void> {
+export async function downloadAddon(fileId: string, path: string) {
   await vscode.window.withProgress(
     { title: "Assay", location: vscode.ProgressLocation.Notification },
     async function (progress) {
       progress.report({
         message: "Downloading Addon",
       });
+
       const url = `${constants.downloadBaseURL}${fileId}`;
       const response = await fetch(url);
       if (!response.ok) {
         vscode.window.showErrorMessage("Download failed");
-        throw new Error("Download failed");
+        throw new Error("Request failed");
       }
+
       const dest = fs.createWriteStream(path, { flags: "w" });
       dest.write(await response.buffer());
       dest.close();

--- a/src/amo/utils/addonDownload.ts
+++ b/src/amo/utils/addonDownload.ts
@@ -8,21 +8,23 @@ async function fetchDownloadFile(fileId: string) {
   const url = `${constants.downloadBaseURL}${fileId}`;
   const response = await fetch(url);
   if (!response.ok) {
-    vscode.window
+    await vscode.window
       .showErrorMessage(
         `(Status ${response.status}): Could not fetch download file.`,
         { modal: true },
-        "Try Again",
-        "Fetch New Addon"
+        { title: "Try Again" },
+        { title: "Fetch New Addon" }
       )
-      .then((action) => {
-        if (action === "Try Again") {
-          fetchDownloadFile(fileId);
-        } else if (action === "Fetch New Addon") {
+      .then(async (action) => {
+        if (action?.title === "Try Again") {
+          return await fetchDownloadFile(fileId);
+        } else if (action?.title === "Fetch New Addon") {
           vscode.commands.executeCommand("assay.get");
+          throw new Error("Process restarted");
+        } else {
+          throw new Error("Request failed");
         }
       });
-    throw new Error("Request failed");
   }
   return response;
 }
@@ -39,23 +41,23 @@ export async function downloadAddon(fileId: string, path: string) {
       const dest = fs.createWriteStream(path, { flags: "w" });
       dest.write(await response.buffer());
       dest.close();
+
       if (!fs.existsSync(path)) {
-        vscode.window
-          .showErrorMessage(
-            `Could not download addon to ${path}`,
-            { modal: true },
-            "Try Again",
-            "Fetch New Addon"
-          )
-          .then((action) => {
-            if (action === "Try Again") {
-              fs.rmSync(path);
-              downloadAddon(fileId, path);
-            } else if (action === "Fetch New Addon") {
-              vscode.commands.executeCommand("assay.get");
-            }
-          });
-        throw new Error("Download failed");
+        const action = await vscode.window.showErrorMessage(
+          `Could not download addon to ${path}.`,
+          { modal: true },
+          { title: "Try Again" },
+          { title: "Fetch New Addon" }
+        );
+
+        if (action?.title === "Try Again") {
+          return await downloadAddon(fileId, path);
+        } else if (action?.title === "Fetch New Addon") {
+          vscode.commands.executeCommand("assay.get");
+          throw new Error("Process restarted");
+        } else {
+          throw new Error("Download failed");
+        }
       }
     }
   );

--- a/src/amo/utils/addonDownload.ts
+++ b/src/amo/utils/addonDownload.ts
@@ -2,29 +2,19 @@ import * as fs from "fs";
 import fetch from "node-fetch";
 import * as vscode from "vscode";
 
+import { showErrorMessage } from "./processErrors";
 import constants from "../../config/config";
 
 async function fetchDownloadFile(fileId: string) {
   const url = `${constants.downloadBaseURL}${fileId}`;
   const response = await fetch(url);
   if (!response.ok) {
-    await vscode.window
-      .showErrorMessage(
-        `(Status ${response.status}): Could not fetch download file.`,
-        { modal: true },
-        { title: "Try Again" },
-        { title: "Fetch New Addon" }
-      )
-      .then(async (action) => {
-        if (action?.title === "Try Again") {
-          return await fetchDownloadFile(fileId);
-        } else if (action?.title === "Fetch New Addon") {
-          vscode.commands.executeCommand("assay.get");
-          throw new Error("Process restarted");
-        } else {
-          throw new Error("Request failed");
-        }
-      });
+    await showErrorMessage(
+      `(Status ${response.status}): Could not fetch addon info.`,
+      "Request failed",
+      fetchDownloadFile,
+      [fileId]
+    );
   }
   return response;
 }
@@ -37,27 +27,17 @@ export async function downloadAddon(fileId: string, path: string) {
         message: "Downloading Addon",
       });
       const response = await fetchDownloadFile(fileId);
-
       const dest = fs.createWriteStream(path, { flags: "w" });
       dest.write(await response.buffer());
       dest.close();
 
       if (!fs.existsSync(path)) {
-        const action = await vscode.window.showErrorMessage(
+        await showErrorMessage(
           `Could not download addon to ${path}.`,
-          { modal: true },
-          { title: "Try Again" },
-          { title: "Fetch New Addon" }
+          "Download failed",
+          downloadAddon,
+          [fileId, path]
         );
-
-        if (action?.title === "Try Again") {
-          return await downloadAddon(fileId, path);
-        } else if (action?.title === "Fetch New Addon") {
-          vscode.commands.executeCommand("assay.get");
-          throw new Error("Process restarted");
-        } else {
-          throw new Error("Download failed");
-        }
       }
     }
   );

--- a/src/amo/utils/addonDownload.ts
+++ b/src/amo/utils/addonDownload.ts
@@ -4,14 +4,29 @@ import * as vscode from "vscode";
 
 import constants from "../../config/config";
 
-export async function downloadAddon(fileId: string, path: string) {
-  const url = `${constants.downloadBaseURL}${fileId}`;
-  const response = await fetch(url);
-
-  if (response.ok) {
-    const dest = fs.createWriteStream(path, { flags: "w" });
-    dest.write(await response.buffer());
-    dest.close();
-    vscode.window.showInformationMessage("Download complete");
-  }
+export async function downloadAddon(
+  fileId: string,
+  path: string
+): Promise<void> {
+  await vscode.window.withProgress(
+    { title: "Assay", location: vscode.ProgressLocation.Notification },
+    async function (progress) {
+      progress.report({
+        message: "Downloading Addon",
+      });
+      const url = `${constants.downloadBaseURL}${fileId}`;
+      const response = await fetch(url);
+      if (!response.ok) {
+        vscode.window.showErrorMessage("Download failed");
+        throw new Error("Download failed");
+      }
+      const dest = fs.createWriteStream(path, { flags: "w" });
+      dest.write(await response.buffer());
+      dest.close();
+      if (!fs.existsSync(path)) {
+        vscode.window.showErrorMessage("Download failed");
+        throw new Error("Download failed");
+      }
+    }
+  );
 }

--- a/src/amo/utils/addonDownload.ts
+++ b/src/amo/utils/addonDownload.ts
@@ -4,6 +4,29 @@ import * as vscode from "vscode";
 
 import constants from "../../config/config";
 
+async function fetchDownloadFile(fileId: string) {
+  const url = `${constants.downloadBaseURL}${fileId}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    vscode.window
+      .showErrorMessage(
+        `(Status ${response.status}): Could not fetch download file.`,
+        { modal: true },
+        "Try Again",
+        "Fetch New Addon"
+      )
+      .then((action) => {
+        if (action === "Try Again") {
+          fetchDownloadFile(fileId);
+        } else if (action === "Fetch New Addon") {
+          vscode.commands.executeCommand("assay.get");
+        }
+      });
+    throw new Error("Request failed");
+  }
+  return response;
+}
+
 export async function downloadAddon(fileId: string, path: string) {
   await vscode.window.withProgress(
     { title: "Assay", location: vscode.ProgressLocation.Notification },
@@ -11,19 +34,27 @@ export async function downloadAddon(fileId: string, path: string) {
       progress.report({
         message: "Downloading Addon",
       });
-
-      const url = `${constants.downloadBaseURL}${fileId}`;
-      const response = await fetch(url);
-      if (!response.ok) {
-        vscode.window.showErrorMessage("Download failed");
-        throw new Error("Request failed");
-      }
+      const response = await fetchDownloadFile(fileId);
 
       const dest = fs.createWriteStream(path, { flags: "w" });
       dest.write(await response.buffer());
       dest.close();
       if (!fs.existsSync(path)) {
-        vscode.window.showErrorMessage("Download failed");
+        vscode.window
+          .showErrorMessage(
+            `Could not download addon to ${path}`,
+            { modal: true },
+            "Try Again",
+            "Fetch New Addon"
+          )
+          .then((action) => {
+            if (action === "Try Again") {
+              fs.rmSync(path);
+              downloadAddon(fileId, path);
+            } else if (action === "Fetch New Addon") {
+              vscode.commands.executeCommand("assay.get");
+            }
+          });
         throw new Error("Download failed");
       }
     }

--- a/src/amo/utils/addonExtract.ts
+++ b/src/amo/utils/addonExtract.ts
@@ -33,8 +33,25 @@ export async function extractAddon(
   fs.unlinkSync(compressedFilePath); // remove xpi
 
   if (!fs.existsSync(addonVersionFolderPath)) {
-    vscode.window.showErrorMessage("Extraction failed");
-    return;
+    vscode.window
+      .showErrorMessage(
+        `Extraction failed. Could not find ${addonVersionFolderPath}`,
+        { modal: true },
+        "Try Again",
+        "Fetch New Addon"
+      )
+      .then((action) => {
+        if (action === "Try Again") {
+          extractAddon(
+            compressedFilePath,
+            addonFolderPath,
+            addonVersionFolderPath
+          );
+        } else if (action === "Fetch New Addon") {
+          vscode.commands.executeCommand("assay.get");
+        }
+      });
+    throw new Error("Extraction failed");
   }
 
   vscode.window.showInformationMessage("Extraction complete");

--- a/src/amo/utils/addonExtract.ts
+++ b/src/amo/utils/addonExtract.ts
@@ -2,6 +2,8 @@ import * as extract from "extract-zip";
 import * as fs from "fs";
 import * as vscode from "vscode";
 
+import { showErrorMessage } from "./processErrors";
+
 export function dirExistsOrMake(dir: string) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir);
@@ -33,27 +35,12 @@ export async function extractAddon(
   fs.unlinkSync(compressedFilePath); // remove xpi
 
   if (!fs.existsSync(addonVersionFolderPath)) {
-    await vscode.window
-      .showErrorMessage(
-        `Extraction failed. Could not find ${addonVersionFolderPath}`,
-        { modal: true },
-        { title: "Try Again" },
-        { title: "Fetch New Addon" }
-      )
-      .then(async (action) => {
-        if (action?.title === "Try Again") {
-          return await extractAddon(
-            compressedFilePath,
-            addonFolderPath,
-            addonVersionFolderPath
-          );
-        } else if (action?.title === "Fetch New Addon") {
-          vscode.commands.executeCommand("assay.get");
-          throw new Error("Process restarted");
-        } else {
-          throw new Error("Extraction failed");
-        }
-      });
+    await showErrorMessage(
+      `Extraction failed. Could not find ${addonVersionFolderPath}`,
+      "Extraction failed",
+      extractAddon,
+      [compressedFilePath, addonFolderPath, addonVersionFolderPath]
+    );
   }
 
   vscode.window.showInformationMessage("Extraction complete");

--- a/src/amo/utils/addonExtract.ts
+++ b/src/amo/utils/addonExtract.ts
@@ -13,75 +13,34 @@ export async function extractAddon(
   compressedFilePath: string,
   addonFolderPath: string,
   addonVersionFolderPath: string
-): Promise<void> {
-  return vscode.window.withProgress(
-    { title: "Assay", location: vscode.ProgressLocation.Notification },
-    function (progress) {
-      progress.report({ message: "Extracting" });
-      return startExtracting(
-        compressedFilePath,
-        addonFolderPath,
-        addonVersionFolderPath
-      );
-    }
-  );
-}
+) {
+  dirExistsOrMake(addonFolderPath);
 
-function startExtracting(
-  compressedFilePath: string,
-  addonFolderPath: string,
-  addonVersionFolderPath: string
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    dirExistsOrMake(addonFolderPath);
-    if (!dirExistsOrMake(addonVersionFolderPath)) {
-      askForOverwriteConfirmation()
-        .then((shouldOverwrite) => {
-          if (!shouldOverwrite) {
-            fs.unlinkSync(compressedFilePath);
-            reject(new Error("Extraction cancelled"));
-          } else {
-            continueExtraction(compressedFilePath, addonVersionFolderPath)
-              .then(resolve)
-              .catch(reject);
-          }
-        })
-        .catch(reject);
-    } else {
-      continueExtraction(compressedFilePath, addonVersionFolderPath)
-        .then(resolve)
-        .catch(reject);
-    }
-  });
-}
-
-async function askForOverwriteConfirmation(): Promise<boolean> {
-  return vscode.window
-    .showQuickPick(["Yes", "No"], {
+  if (!dirExistsOrMake(addonVersionFolderPath)) {
+    const choice = await vscode.window.showQuickPick(["Yes", "No"], {
       placeHolder: "Addon already exists. Overwrite?",
-    })
-    .then((choice) => choice === "Yes");
-}
-
-async function continueExtraction(
-  compressedFilePath: string,
-  addonVersionFolderPath: string
-): Promise<void> {
-  return extract(compressedFilePath, { dir: addonVersionFolderPath }).then(
-    () => {
-      fs.unlinkSync(compressedFilePath); // remove xpi
-
-      if (!fs.existsSync(addonVersionFolderPath)) {
-        vscode.window.showErrorMessage("Extraction failed");
-        return Promise.reject(new Error("Extraction failed"));
-      }
-
-      vscode.window.showInformationMessage("Extraction complete");
-
-      // make files read-only
-      fs.readdirSync(addonVersionFolderPath).forEach((file) => {
-        fs.chmodSync(`${addonVersionFolderPath}/${file}`, 0o444);
-      });
+    });
+    if (choice === "No" || !choice) {
+      fs.unlinkSync(compressedFilePath);
+      throw new Error("Extraction cancelled");
     }
-  );
+  }
+
+  await extract(compressedFilePath, {
+    dir: addonVersionFolderPath,
+  });
+
+  fs.unlinkSync(compressedFilePath); // remove xpi
+
+  if (!fs.existsSync(addonVersionFolderPath)) {
+    vscode.window.showErrorMessage("Extraction failed");
+    return;
+  }
+
+  vscode.window.showInformationMessage("Extraction complete");
+
+  // make files read-only
+  fs.readdirSync(addonVersionFolderPath).forEach((file) => {
+    fs.chmodSync(`${addonVersionFolderPath}/${file}`, 0o444);
+  });
 }

--- a/src/amo/utils/addonExtract.ts
+++ b/src/amo/utils/addonExtract.ts
@@ -14,33 +14,49 @@ export async function extractAddon(
   addonFolderPath: string,
   addonVersionFolderPath: string
 ) {
-  dirExistsOrMake(addonFolderPath);
+  vscode.window.withProgress(
+    { title: "Assay", location: vscode.ProgressLocation.Notification },
+    function (progress) {
+      progress.report({
+        message: "Extracting",
+      });
 
-  if (!dirExistsOrMake(addonVersionFolderPath)) {
-    const choice = await vscode.window.showQuickPick(["Yes", "No"], {
-      placeHolder: "Addon already exists. Overwrite?",
-    });
-    if (choice === "No" || !choice) {
-      fs.unlinkSync(compressedFilePath);
-      return;
+      return new Promise((resolve, reject) => {
+        dirExistsOrMake(addonFolderPath);
+        if (!dirExistsOrMake(addonVersionFolderPath)) {
+          vscode.window
+            .showQuickPick(["Yes", "No"], {
+              placeHolder: "Addon already exists. Overwrite?",
+            })
+            .then((choice) => {
+              if (choice === "No" || !choice) {
+                fs.unlinkSync(compressedFilePath);
+                reject(new Error("Extraction cancelled"));
+              }
+            });
+        }
+
+
+        extract(compressedFilePath, {
+          dir: addonVersionFolderPath,
+        }).then(() => {
+          fs.unlinkSync(compressedFilePath); // remove xpi
+
+          if (!fs.existsSync(addonVersionFolderPath)) {
+            vscode.window.showErrorMessage("Extraction failed");
+            return Promise.reject(new Error("Extraction failed"));
+          }
+
+          vscode.window.showInformationMessage("Extraction complete");
+
+          // make files read-only
+          fs.readdirSync(addonVersionFolderPath).forEach((file) => {
+            fs.chmodSync(`${addonVersionFolderPath}/${file}`, 0o444);
+          });
+
+          resolve(null);
+        });
+      });
     }
-  }
-
-  await extract(compressedFilePath, {
-    dir: addonVersionFolderPath,
-  });
-
-  fs.unlinkSync(compressedFilePath); // remove xpi
-
-  if (!fs.existsSync(addonVersionFolderPath)) {
-    vscode.window.showErrorMessage("Extraction failed");
-    return;
-  }
-
-  vscode.window.showInformationMessage("Extraction complete");
-
-  // make files read-only
-  fs.readdirSync(addonVersionFolderPath).forEach((file) => {
-    fs.chmodSync(`${addonVersionFolderPath}/${file}`, 0o444);
-  });
+  );
 }

--- a/src/amo/utils/addonInfo.ts
+++ b/src/amo/utils/addonInfo.ts
@@ -11,7 +11,20 @@ export async function getAddonInfo(input: string): Promise<addonInfoResponse> {
   const url = `${constants.apiBaseURL}addons/addon/${slug}`;
   const response = await fetch(url);
   if (!response.ok) {
-    vscode.window.showErrorMessage("Failed to fetch addon info");
+    vscode.window
+      .showErrorMessage(
+        ` (Status ${response.status}): Could not fetch addon info.`,
+        { modal: true },
+        "Try Again",
+        "Fetch New Addon"
+      )
+      .then((action) => {
+        if (action === "Try Again") {
+          return getAddonInfo(input);
+        } else if (action === "Fetch New Addon") {
+          vscode.commands.executeCommand("assay.get");
+        }
+      });
     throw new Error("Failed to fetch addon info");
   }
   const json = await response.json();

--- a/src/amo/utils/addonInfo.ts
+++ b/src/amo/utils/addonInfo.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import * as vscode from "vscode";
 
+import { showErrorMessage } from "./processErrors";
 import constants from "../../config/config";
 import { addonInfoResponse } from "../types";
 
@@ -11,21 +12,12 @@ export async function getAddonInfo(input: string): Promise<addonInfoResponse> {
   const url = `${constants.apiBaseURL}addons/addon/${slug}`;
   const response = await fetch(url);
   if (!response.ok) {
-    vscode.window
-      .showErrorMessage(
-        ` (Status ${response.status}): Could not fetch addon info.`,
-        { modal: true },
-        "Try Again",
-        "Fetch New Addon"
-      )
-      .then((action) => {
-        if (action === "Try Again") {
-          return getAddonInfo(input);
-        } else if (action === "Fetch New Addon") {
-          vscode.commands.executeCommand("assay.get");
-        }
-      });
-    throw new Error("Failed to fetch addon info");
+    await showErrorMessage(
+      `(Status ${response.status}): Could not fetch addon info.`,
+      "Failed to fetch addon info",
+      getAddonInfo,
+      [input]
+    );
   }
   const json = await response.json();
   return json;

--- a/src/amo/utils/addonInfo.ts
+++ b/src/amo/utils/addonInfo.ts
@@ -1,13 +1,19 @@
 import fetch from "node-fetch";
+import * as vscode from "vscode";
 
 import constants from "../../config/config";
+import { addonInfoResponse } from "../types";
 
-export async function getAddonInfo(input: string) {
+export async function getAddonInfo(input: string): Promise<addonInfoResponse> {
   const slug: string = input.includes("/")
     ? input.split("addon/")[1].split("/")[0]
     : input;
   const url = `${constants.apiBaseURL}addons/addon/${slug}`;
   const response = await fetch(url);
+  if (!response.ok) {
+    vscode.window.showErrorMessage("Failed to fetch addon info");
+    throw new Error("Failed to fetch addon info");
+  }
   const json = await response.json();
   return json;
 }

--- a/src/amo/utils/addonVersions.ts
+++ b/src/amo/utils/addonVersions.ts
@@ -5,62 +5,74 @@ import constants from "../../config/config";
 import { addonVersion } from "../types";
 
 export async function getAddonVersions(input: string, next?: string) {
-  if (next) {
-    const url = next;
+  try {
+    if (next) {
+      const url = next;
+      const response = await fetch(url);
+      const json = await response.json();
+      return json;
+    }
+
+    const slug: string = input.includes("/")
+      ? input.split("addon/")[1].split("/")[0]
+      : input;
+    const url = `${constants.apiBaseURL}addons/addon/${slug}/versions/`;
     const response = await fetch(url);
     const json = await response.json();
     return json;
+  } catch (error) {
+    throw new Error("Failed to fetch versions");
   }
-  const slug: string = input.includes("/")
-    ? input.split("addon/")[1].split("/")[0]
-    : input;
-  const url = `${constants.apiBaseURL}addons/addon/${slug}/versions/`;
-  const response = await fetch(url);
-  const json = await response.json();
-  return json;
 }
 
-export async function getVersionChoice(
+export function getVersionChoice(
   input: string
-): Promise<{ fileID: string; version: string } | undefined> {
-  const versions: addonVersion[] = [];
-  let next: string | undefined = undefined;
-  let init = true;
+): Promise<{ fileID: string; version: string }> {
+  return new Promise((resolve, reject) => {
+    const versions: addonVersion[] = [];
+    let next: string | undefined = undefined;
+    let init = true;
 
-  do {
-    if (next || init) {
-      init = false;
-      const res = await getAddonVersions(input, next);
-      versions.push(...res.results);
-      next = res.next;
-    }
-
-    const versionItems = versions.map((version) => version.version);
-    next ? versionItems.push("More") : null;
-
-    const choice = await vscode.window.showQuickPick(versionItems, {
-      placeHolder: "Choose a version",
-    });
-
-    if (choice === "More") {
-      continue;
-    } else if (choice) {
-      const chosenVersion = versions.find(
-        (version) => version.version === choice
-      );
-
-      if (chosenVersion) {
-        return {
-          fileID: chosenVersion.file.id,
-          version: chosenVersion.version,
-        };
+    const processNextVersion = () => {
+      if (next || init) {
+        init = false;
+        getAddonVersions(input, next).then((res) => {
+          versions.push(...res.results);
+          next = res.next;
+          promptVersionChoice();
+        });
       } else {
-        vscode.window.showErrorMessage("No version file found");
-        return;
+        promptVersionChoice();
       }
-    } else {
-      break;
-    }
-    // eslint-disable-next-line no-constant-condition
-  } while (true);
+    };
+
+    const promptVersionChoice = () => {
+      const versionItems = versions.map((version) => version.version);
+      next ? versionItems.push("More") : null;
+
+      vscode.window
+        .showQuickPick(versionItems, { placeHolder: "Choose a version" })
+        .then((choice) => {
+          if (choice === "More") {
+            processNextVersion();
+          } else if (choice) {
+            const chosenVersion = versions.find(
+              (version) => version.version === choice
+            );
+
+            if (chosenVersion) {
+              resolve({
+                fileID: chosenVersion.file.id,
+                version: chosenVersion.version,
+              });
+            } else {
+              reject(new Error("No version file found"));
+            }
+          } else {
+            reject(new Error("No version choice provided"));
+          }
+        });
+    };
+    processNextVersion();
+  });
 }

--- a/src/amo/utils/addonVersions.ts
+++ b/src/amo/utils/addonVersions.ts
@@ -1,70 +1,36 @@
 import fetch from "node-fetch";
 import * as vscode from "vscode";
 
+import { showErrorMessage } from "./processErrors";
 import constants from "../../config/config";
 import { addonVersion } from "../types";
 
-async function getPaginatedVersions(input: string, next: string) {
-  const url = next;
-  const response = await fetch(url);
-  if (!response.ok) {
-    await vscode.window
-      .showErrorMessage(
-        `(Status ${response.status}): Could not fetch versions.`,
-        { modal: true },
-        { title: "Try Again" },
-        { title: "Fetch New Addon" }
-      )
-      .then(async (action) => {
-        if (action?.title === "Try Again") {
-          return await getAddonVersions(input, next);
-        } else if (action?.title === "Fetch New Addon") {
-          vscode.commands.executeCommand("assay.get");
-          throw new Error("Process restarted");
-        } else {
-          throw new Error("Failed to fetch versions");
-        }
-      });
-  }
-  const json = await response.json();
-  return json;
-}
-
-async function getFirstVersions(input: string) {
+export async function getAddonVersions(input: string, next?: string) {
   const slug: string = input.includes("/")
     ? input.split("addon/")[1].split("/")[0]
     : input;
-  const url = `${constants.apiBaseURL}addons/addon/${slug}/versions/`;
+  const url = next
+    ? next
+    : `${constants.apiBaseURL}addons/addon/${slug}/versions/`;
   const response = await fetch(url);
+
   if (!response.ok) {
-    await vscode.window
-      .showErrorMessage(
-        `(Status ${response.status}) Addon ${slug} not found.`,
-        { modal: true },
-        { title: "Try Again" },
-        { title: "Fetch New Addon" }
-      )
-      .then(async (action) => {
-        if (action?.title === "Try Again") {
-          return await getAddonVersions(input);
-        } else if (action?.title === "Fetch New Addon") {
-          vscode.commands.executeCommand("assay.get");
-          throw new Error("Process restarted");
-        } else {
-          throw new Error("Failed to fetch addon");
-        }
-      });
+    const errMsgWindow = next
+      ? "Could not fetch more versions"
+      : `Addon ${slug} not found`;
+    const errMsgThrown = next
+      ? "Failed to fetch versions"
+      : "Failed to fetch addon";
+
+    await showErrorMessage(
+      `(Status ${response.status}) ${errMsgWindow}.`,
+      errMsgThrown,
+      getAddonVersions,
+      [input, next]
+    );
   }
   const json = await response.json();
   return json;
-}
-
-export async function getAddonVersions(input: string, next?: string) {
-  if (next) {
-    return getPaginatedVersions(input, next);
-  } else {
-    return getFirstVersions(input);
-  }
 }
 
 export async function getVersionChoice(

--- a/src/amo/utils/addonVersions.ts
+++ b/src/amo/utils/addonVersions.ts
@@ -8,21 +8,23 @@ async function getPaginatedVersions(input: string, next: string) {
   const url = next;
   const response = await fetch(url);
   if (!response.ok) {
-    vscode.window
+    await vscode.window
       .showErrorMessage(
         `(Status ${response.status}): Could not fetch versions.`,
         { modal: true },
-        "Try Again",
-        "Fetch New Addon"
+        { title: "Try Again" },
+        { title: "Fetch New Addon" }
       )
-      .then((action) => {
-        if (action === "Try Again") {
-          getAddonVersions(input, next);
-        } else if (action === "Fetch New Addon") {
+      .then(async (action) => {
+        if (action?.title === "Try Again") {
+          return await getAddonVersions(input, next);
+        } else if (action?.title === "Fetch New Addon") {
           vscode.commands.executeCommand("assay.get");
+          throw new Error("Process restarted");
+        } else {
+          throw new Error("Failed to fetch versions");
         }
       });
-    throw new Error("Failed to fetch versions");
   }
   const json = await response.json();
   return json;
@@ -35,18 +37,23 @@ async function getFirstVersions(input: string) {
   const url = `${constants.apiBaseURL}addons/addon/${slug}/versions/`;
   const response = await fetch(url);
   if (!response.ok) {
-    vscode.window
+    await vscode.window
       .showErrorMessage(
         `(Status ${response.status}) Addon ${slug} not found.`,
         { modal: true },
-        "Try Again"
+        { title: "Try Again" },
+        { title: "Fetch New Addon" }
       )
-      .then((action) => {
-        if (action === "Try Again") {
+      .then(async (action) => {
+        if (action?.title === "Try Again") {
+          return await getAddonVersions(input);
+        } else if (action?.title === "Fetch New Addon") {
           vscode.commands.executeCommand("assay.get");
+          throw new Error("Process restarted");
+        } else {
+          throw new Error("Failed to fetch addon");
         }
       });
-    throw new Error("Failed to fetch addon");
   }
   const json = await response.json();
   return json;

--- a/src/amo/utils/processErrors.ts
+++ b/src/amo/utils/processErrors.ts
@@ -23,6 +23,7 @@ export async function showErrorMessage(
         }
         return tryAgainFunction(...tryAgainFunctionParams);
       } else if (action?.title === fetchNewAddonButton.title) {
+        // restart the process, but also throw an error to end the current process
         vscode.commands.executeCommand("assay.get");
         throw new Error("Process restarted");
       } else {

--- a/src/amo/utils/processErrors.ts
+++ b/src/amo/utils/processErrors.ts
@@ -1,0 +1,32 @@
+import * as vscode from "vscode";
+
+export async function showErrorMessage(
+  message: string,
+  cancelMessage: string,
+  tryAgainFunction: (...args: any[]) => Promise<any>,
+  tryAgainFunctionParams?: any[]
+) {
+  const tryAgainButton = { title: "Try Again" };
+  const fetchNewAddonButton = { title: "Fetch New Addon" };
+
+  await vscode.window
+    .showErrorMessage(
+      message,
+      { modal: true },
+      tryAgainButton,
+      fetchNewAddonButton
+    )
+    .then((action) => {
+      if (action?.title === tryAgainButton.title) {
+        if (!tryAgainFunctionParams) {
+          return tryAgainFunction();
+        }
+        return tryAgainFunction(...tryAgainFunctionParams);
+      } else if (action?.title === fetchNewAddonButton.title) {
+        vscode.commands.executeCommand("assay.get");
+        throw new Error("Process restarted");
+      } else {
+        throw new Error(cancelMessage);
+      }
+    });
+}

--- a/src/test/suite/commands/getAddon.test.ts
+++ b/src/test/suite/commands/getAddon.test.ts
@@ -1,137 +1,55 @@
 import { expect } from "chai";
-import * as fs from "fs";
 import { describe, it, afterEach } from "mocha";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 
-import { downloadAndExtract } from "../../../amo/commands/getAddon";
+import { getInput, getWorkspaceFolder } from "../../../amo/commands/getAddon";
 
-describe("getAddon.ts", () => {
+describe("getAddon.ts", async () => {
   afterEach(() => {
     sinon.restore();
   });
 
-  it("should return undefined if no input is provided", async () => {
-    sinon.stub(vscode.window, "showInputBox").resolves(undefined);
-    const result = await downloadAndExtract();
-    expect(result).to.be.undefined;
-  });
-
-  it("should return undefined if no version is found", async () => {
-    const stub = sinon.stub(vscode.window, "showInputBox");
-    stub.onFirstCall().resolves("test");
-
-    const module = await import("../../../amo/utils/addonVersions");
-    const getVersionChoiceStub = sinon.stub(module, "getVersionChoice");
-    getVersionChoiceStub.resolves(undefined);
-
-    const result = await downloadAndExtract();
-    expect(result).to.be.undefined;
-  });
-
-  it("should return undefined if no metadata is found", async () => {
-    const stub = sinon.stub(vscode.window, "showInputBox");
-    stub.onFirstCall().resolves("test");
-
-    const module = await import("../../../amo/utils/addonVersions");
-    const getVersionChoiceStub = sinon.stub(module, "getVersionChoice");
-    getVersionChoiceStub.resolves({ fileID: "1", version: "test" });
-
-    const module2 = await import("../../../amo/utils/addonInfo");
-    const addonInfoStub = sinon.stub(module2, "getAddonInfo");
-    addonInfoStub.resolves(undefined);
-
-    const result = await downloadAndExtract();
-    expect(result).to.be.undefined;
-  });
-
-  it("should return undefined if the download fails", async () => {
-    const stub = sinon.stub(vscode.window, "showInputBox");
-    stub.onFirstCall().resolves("test");
-
-    const module = await import("../../../amo/utils/addonVersions");
-    const getVersionChoiceStub = sinon.stub(module, "getVersionChoice");
-    getVersionChoiceStub.resolves({ fileID: "1", version: "test" });
-
-    const module2 = await import("../../../amo/utils/addonInfo");
-    const addonInfoStub = sinon.stub(module2, "getAddonInfo");
-    addonInfoStub.resolves({
-      id: "test",
-      name: {
-        en: "test",
-      },
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      default_locale: "en",
-      slug: "test",
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      review_url: "test",
-      guid: "test",
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      current_version: {
-        version: "test",
-        file: {
-          id: "1",
-        },
-      },
+  describe("getInput()", () => {
+    it("should return the input if provided", async () => {
+      const stub = sinon.stub(vscode.window, "showInputBox");
+      stub.onFirstCall().resolves("test");
+      const result = await getInput();
+      expect(result).to.equal("test");
     });
 
-    const stub3 = sinon.stub(vscode.workspace, "workspaceFolders");
-    stub3.value([
-      {
-        uri: {
-          fsPath: "test",
-        },
-      },
-    ]);
-
-    const result = await downloadAndExtract();
-    expect(result).to.be.undefined;
+    it("should raise an error if no input is provided", async () => {
+      const stub = sinon.stub(vscode.window, "showInputBox");
+      stub.onFirstCall().resolves(undefined);
+      try {
+        await getInput();
+      } catch (error) {
+        expect(error).to.be.an("error");
+      }
+    });
   });
 
-  it("should return undefined if the extraction fails", async () => {
-    const stub = sinon.stub(vscode.window, "showInputBox");
-    stub.onFirstCall().resolves("test");
-
-    const module = await import("../../../amo/utils/addonVersions");
-    const getVersionChoiceStub = sinon.stub(module, "getVersionChoice");
-    getVersionChoiceStub.resolves({ fileID: "1", version: "test" });
-
-    const module2 = await import("../../../amo/utils/addonInfo");
-    const addonInfoStub = sinon.stub(module2, "getAddonInfo");
-    addonInfoStub.resolves({
-      id: "test",
-      name: {
-        en: "test",
-      },
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      default_locale: "en",
-      slug: "test",
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      review_url: "test",
-      guid: "test",
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      current_version: {
-        version: "test",
-        file: {
-          id: "1",
+  describe("getWorkspaceFolder()", () => {
+    it("should return the workspace folder if found", async () => {
+      sinon.stub(vscode.workspace, "workspaceFolders").get(() => [
+        {
+          uri: {
+            fsPath: "test",
+          },
         },
-      },
+      ]);
+      const result = getWorkspaceFolder();
+      expect(result).to.equal("test");
     });
 
-    const stub3 = sinon.stub(vscode.workspace, "workspaceFolders");
-    stub3.value([
-      {
-        uri: {
-          fsPath: "test",
-        },
-      },
-    ]);
-
-    const stub4 = sinon.stub(fs, "existsSync");
-    stub4.onFirstCall().returns(true);
-    stub4.onSecondCall().returns(false);
-
-    const result = await downloadAndExtract();
-    expect(result).to.be.undefined;
+    it("should raise an error if no workspace folder is found", async () => {
+      const stub = sinon.stub(vscode.workspace, "workspaceFolders");
+      stub.onFirstCall().returns(undefined);
+      try {
+        getWorkspaceFolder();
+      } catch (error) {
+        expect(error).to.be.an("error");
+      }
+    });
   });
 });

--- a/src/test/suite/utils/AddonDownload.test.ts
+++ b/src/test/suite/utils/AddonDownload.test.ts
@@ -4,47 +4,50 @@ import { afterEach, describe, it } from "mocha";
 import * as fetch from "node-fetch";
 import path = require("path");
 import * as sinon from "sinon";
+import * as vscode from "vscode";
 
 import { downloadAddon } from "../../../amo/utils/addonDownload";
 import constants from "../../../config/config";
 
 describe("addonDownload.ts", async () => {
+  const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
+
   afterEach(() => {
     sinon.restore();
-    const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
     if (fs.existsSync(workspaceFolder)) {
       fs.rmSync(workspaceFolder, { recursive: true });
     }
   });
 
-  it("should download the xpi of the addon", async () => {
-    // mock response
-    const fakeResponse = {
-      ok: true,
-      buffer: () => {
-        return "test data";
-      },
-    };
+  const badResponse = {
+    ok: false,
+    buffer: () => {
+      return "test data";
+    },
+  };
 
-    const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
+  const goodResponse = {
+    ok: true,
+    buffer: () => {
+      return "test data";
+    },
+  };
+
+  const addonId = "123456";
+  const addonSlug = "test-addon";
+  const downloadedFilePath = path.resolve(workspaceFolder, `${addonSlug}.xpi`);
+
+  it("should download the xpi of the addon", async () => {
     if (!fs.existsSync(workspaceFolder)) {
       fs.mkdirSync(workspaceFolder);
     }
 
-    const addonId = "123456";
-    const addonSlug = "test-addon";
-    const downloadedFilePath = path.resolve(
-      workspaceFolder,
-      `${addonSlug}.xpi`
-    );
-
     const stub = sinon.stub();
-    stub.resolves(fakeResponse);
+    stub.resolves(goodResponse);
     sinon.replace(fetch, "default", stub as any);
 
-    const stub2 = sinon.stub();
-    stub2.resolves(true);
-    sinon.replace(fs, "existsSync", stub2 as any);
+    const stub2 = sinon.stub(fs, "existsSync");
+    stub2.onFirstCall().returns(true);
 
     await downloadAddon(addonId, downloadedFilePath);
     sinon.restore();
@@ -61,32 +64,20 @@ describe("addonDownload.ts", async () => {
   });
 
   it("should not make a file if the request failed", async () => {
-    const fakeResponse = {
-      ok: false,
-      buffer: () => {
-        return "test data";
-      },
-    };
-
-    const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
     if (!fs.existsSync(workspaceFolder)) {
       fs.mkdirSync(workspaceFolder);
     }
 
-    const addonId = "123456";
-    const addonSlug = "test-addon";
-    const downloadedFilePath = path.resolve(
-      workspaceFolder,
-      `${addonSlug}.xpi`
-    );
-
     const stub = sinon.stub();
-    stub.resolves(fakeResponse);
+    stub.resolves(badResponse);
     sinon.replace(fetch, "default", stub as any);
+
+    const stub2 = sinon.stub(vscode.window, "showErrorMessage");
+    stub2.resolves({ title: "Cancel" });
 
     try {
       await downloadAddon(addonId, downloadedFilePath);
-      expect.fail("Should have thrown an error");
+      expect(false).to.be.true;
     } catch (e: any) {
       expect(e.message).to.equal("Request failed");
       expect(stub.calledOnce).to.be.true;
@@ -95,6 +86,136 @@ describe("addonDownload.ts", async () => {
 
       await new Promise((resolve) => setTimeout(resolve, 200));
       expect(fs.existsSync(downloadedFilePath)).to.be.false;
+    }
+  });
+
+  it("should try again if the request failed", async () => {
+    if (!fs.existsSync(workspaceFolder)) {
+      fs.mkdirSync(workspaceFolder);
+    }
+
+    const stub = sinon.stub();
+    stub.onFirstCall().resolves(badResponse);
+    stub.onSecondCall().resolves(goodResponse);
+    sinon.replace(fetch, "default", stub as any);
+
+    const stub2 = sinon.stub(fs, "existsSync");
+    stub2.onFirstCall().returns(true);
+
+    const stub3 = sinon.stub(vscode.window, "showErrorMessage");
+    stub3.onFirstCall().resolves({ title: "Try Again" });
+
+    await downloadAddon(addonId, downloadedFilePath);
+    expect(stub.calledTwice).to.be.true;
+    expect(stub.calledWith(`${constants.downloadBaseURL}${addonId}`)).to.be
+      .true;
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const exists = await fs.promises
+      .access(downloadedFilePath, fs.constants.F_OK)
+      .then(() => true)
+      .catch(() => false);
+    expect(exists).to.be.true;
+  });
+
+  it("should restart the get process if the user chooses to", async () => {
+    if (!fs.existsSync(workspaceFolder)) {
+      fs.mkdirSync(workspaceFolder);
+    }
+
+    const stub = sinon.stub();
+    stub.onFirstCall().resolves(badResponse);
+    sinon.replace(fetch, "default", stub as any);
+
+    const stub2 = sinon.stub(fs, "existsSync");
+    stub2.onFirstCall().returns(true);
+
+    const stub3 = sinon.stub(vscode.window, "showErrorMessage");
+    stub3.onFirstCall().resolves({ title: "Fetch New Addon" });
+
+    try {
+      await downloadAddon(addonId, downloadedFilePath);
+      expect(false).to.be.true;
+    } catch (e: any) {
+      expect(e.message).to.equal("Process restarted");
+    }
+  });
+
+  it("should try again if the download failed", async () => {
+    if (!fs.existsSync(workspaceFolder)) {
+      fs.mkdirSync(workspaceFolder);
+    }
+
+    const stub = sinon.stub();
+    stub.resolves(goodResponse);
+    sinon.replace(fetch, "default", stub as any);
+
+    const stub2 = sinon.stub(fs, "existsSync");
+    stub2.onFirstCall().returns(false);
+    stub2.onSecondCall().returns(true);
+
+    const stub3 = sinon.stub(vscode.window, "showErrorMessage");
+    stub3.resolves({ title: "Try Again" });
+
+    await downloadAddon(addonId, downloadedFilePath);
+    expect(stub.calledWith(`${constants.downloadBaseURL}${addonId}`)).to.be
+      .true;
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const exists = await fs.promises
+      .access(downloadedFilePath, fs.constants.F_OK)
+      .then(() => true)
+      .catch(() => false);
+    expect(exists).to.be.true;
+  });
+
+  it("should restart the get process if the user chooses to", async () => {
+    if (!fs.existsSync(workspaceFolder)) {
+      fs.mkdirSync(workspaceFolder);
+    }
+
+    const stub = sinon.stub();
+    stub.resolves(goodResponse);
+    sinon.replace(fetch, "default", stub as any);
+
+    const stub2 = sinon.stub(fs, "existsSync");
+    stub2.onFirstCall().returns(false);
+    stub2.onSecondCall().returns(true);
+
+    const stub3 = sinon.stub(vscode.window, "showErrorMessage");
+    stub3.resolves({ title: "Fetch New Addon" });
+
+    sinon.stub(vscode.commands, "executeCommand").returns(Promise.resolve());
+
+    try {
+      await downloadAddon(addonId, downloadedFilePath);
+      expect(false).to.be.true;
+    } catch (e: any) {
+      expect(e.message).to.equal("Process restarted");
+    }
+  });
+
+  it("should throw an error if the user cancels", async () => {
+    if (!fs.existsSync(workspaceFolder)) {
+      fs.mkdirSync(workspaceFolder);
+    }
+
+    const stub = sinon.stub();
+    stub.resolves(goodResponse);
+    sinon.replace(fetch, "default", stub as any);
+
+    const stub2 = sinon.stub(fs, "existsSync");
+    stub2.onFirstCall().returns(false);
+    stub2.onSecondCall().returns(true);
+
+    const stub3 = sinon.stub(vscode.window, "showErrorMessage");
+    stub3.resolves({ title: "Cancel" });
+
+    try {
+      await downloadAddon(addonId, downloadedFilePath);
+      expect(false).to.be.true;
+    } catch (e: any) {
+      expect(e.message).to.equal("Download failed");
     }
   });
 });

--- a/src/test/suite/utils/AddonExtract.test.ts
+++ b/src/test/suite/utils/AddonExtract.test.ts
@@ -6,167 +6,247 @@ import path = require("path");
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 
-import { extractAddon } from "../../../amo/utils/addonExtract";
+import { extractAddon, dirExistsOrMake } from "../../../amo/utils/addonExtract";
 
 describe("AddonExtract.ts", async () => {
+  const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
+  const compressedFilePath = path.resolve(workspaceFolder, "test-addon.xpi");
+
   afterEach(() => {
     sinon.restore();
-    // remove test workspace
-    const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
     if (fs.existsSync(workspaceFolder)) {
       fs.rmSync(workspaceFolder, { recursive: true });
     }
   });
 
-  it("should extract a new addon, remove the xpi, and make files read only", async () => {
-    const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
-    if (!fs.existsSync(workspaceFolder)) {
-      fs.mkdirSync(workspaceFolder);
-    }
-
-    // create xpi file
+  async function createXPI() {
     const zip = new jszip();
     zip.file("test.txt", "test data inside txt");
-    const compressedFilePath = path.resolve(workspaceFolder, "test-addon.xpi");
     await zip.generateAsync({ type: "nodebuffer" }).then((content) => {
       fs.writeFileSync(compressedFilePath, content);
     });
+  }
 
-    // extract xpi
-    const addonGUID = "test-addon";
-    const addonVersion = "1.0.0";
-    const extractedworkspaceFolder = path.resolve(workspaceFolder, addonGUID);
-    const extractedVersionFolder = path.resolve(
-      extractedworkspaceFolder,
-      addonVersion
-    );
+  const addonGUID = "test-addon";
+  const addonVersion = "1.0.0";
+  const extractedworkspaceFolder = path.resolve(workspaceFolder, addonGUID);
+  const extractedVersionFolder = path.resolve(
+    extractedworkspaceFolder,
+    addonVersion
+  );
 
-    await extractAddon(
-      compressedFilePath,
-      extractedworkspaceFolder,
-      extractedVersionFolder
-    );
-    expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;
-    expect(fs.existsSync(extractedVersionFolder)).to.be.true;
-    expect(fs.existsSync(compressedFilePath)).to.be.false;
-    const fileStats = fs.statSync(
-      path.resolve(extractedVersionFolder, "test.txt")
-    );
-    expect(fileStats.mode).to.equal(0o100444);
-  });
+  describe("extractAddon()", async () => {
+    it("should extract a new addon, remove the xpi, and make files read only", async () => {
+      if (!fs.existsSync(workspaceFolder)) {
+        fs.mkdirSync(workspaceFolder);
+      }
 
-  it("should overwrite an existing addon", async () => {
-    const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
-    if (!fs.existsSync(workspaceFolder)) {
-      fs.mkdirSync(workspaceFolder);
-    }
+      await createXPI();
 
-    // create xpi file
-    const zip = new jszip();
-    zip.file("test.txt", "test data inside txt");
-    const compressedFilePath = path.resolve(workspaceFolder, "test-addon.xpi");
-    await zip.generateAsync({ type: "nodebuffer" }).then((content) => {
-      fs.writeFileSync(compressedFilePath, content);
-    });
-
-    // extract xpi
-    const addonGUID = "test-addon";
-    const addonVersion = "1.0.0";
-    const extractedworkspaceFolder = path.resolve(workspaceFolder, addonGUID);
-    const extractedVersionFolder = path.resolve(
-      extractedworkspaceFolder,
-      addonVersion
-    );
-
-    fs.mkdirSync(extractedworkspaceFolder);
-    fs.mkdirSync(extractedVersionFolder);
-
-    // create a file in the version folder
-    fs.writeFileSync(
-      path.resolve(extractedVersionFolder, "test.txt"),
-      "replace me"
-    );
-
-    // make a stub for the quickpick and force it to say yes
-    const stub = sinon.stub();
-    stub.onCall(0).returns("Yes");
-    sinon.replace(vscode.window, "showQuickPick", stub);
-
-    await extractAddon(
-      compressedFilePath,
-      extractedworkspaceFolder,
-      extractedVersionFolder
-    );
-    expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;
-    expect(fs.existsSync(extractedVersionFolder)).to.be.true;
-    expect(fs.existsSync(compressedFilePath)).to.be.false;
-    const fileStats = fs.statSync(
-      path.resolve(extractedVersionFolder, "test.txt")
-    );
-    expect(fileStats.mode).to.equal(0o100444);
-
-    const fileContent = fs.readFileSync(
-      path.resolve(extractedVersionFolder, "test.txt"),
-      "utf-8"
-    );
-    expect(fileContent).to.equal("test data inside txt");
-  });
-
-  it("should not overwrite an existing addon", async () => {
-    const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
-    if (!fs.existsSync(workspaceFolder)) {
-      fs.mkdirSync(workspaceFolder);
-    }
-
-    // create xpi file
-    const zip = new jszip();
-    zip.file("test.txt", "test data inside txt");
-    const compressedFilePath = path.resolve(workspaceFolder, "test-addon.xpi");
-    await zip.generateAsync({ type: "nodebuffer" }).then((content) => {
-      fs.writeFileSync(compressedFilePath, content);
-    });
-
-    // extract xpi
-    const addonGUID = "test-addon";
-    const addonVersion = "1.0.0";
-    const extractedworkspaceFolder = path.resolve(workspaceFolder, addonGUID);
-    const extractedVersionFolder = path.resolve(
-      extractedworkspaceFolder,
-      addonVersion
-    );
-
-    fs.mkdirSync(extractedworkspaceFolder);
-    fs.mkdirSync(extractedVersionFolder);
-
-    // create a file in the version folder
-    fs.writeFileSync(
-      path.resolve(extractedVersionFolder, "test.txt"),
-      "replace me"
-    );
-
-    // make a stub for the quickpick and force it to say no
-    const stub = sinon.stub();
-    stub.onCall(0).returns("No");
-    sinon.replace(vscode.window, "showQuickPick", stub);
-
-    try {
       await extractAddon(
         compressedFilePath,
         extractedworkspaceFolder,
         extractedVersionFolder
       );
-      expect.fail("Should have thrown an error");
-    } catch (e: any) {
-      expect(e.message).to.equal("Extraction cancelled");
       expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;
       expect(fs.existsSync(extractedVersionFolder)).to.be.true;
       expect(fs.existsSync(compressedFilePath)).to.be.false;
+      const fileStats = fs.statSync(
+        path.resolve(extractedVersionFolder, "test.txt")
+      );
+      expect(fileStats.mode).to.equal(0o100444);
+    });
+
+    it("should overwrite an existing addon", async () => {
+      if (!fs.existsSync(workspaceFolder)) {
+        fs.mkdirSync(workspaceFolder);
+      }
+
+      await createXPI();
+
+      fs.mkdirSync(extractedworkspaceFolder);
+      fs.mkdirSync(extractedVersionFolder);
+
+      // create a file in the version folder
+      fs.writeFileSync(
+        path.resolve(extractedVersionFolder, "test.txt"),
+        "replace me"
+      );
+
+      // make a stub for the quickpick and force it to say yes
+      const stub = sinon.stub();
+      stub.onCall(0).returns("Yes");
+      sinon.replace(vscode.window, "showQuickPick", stub);
+
+      await extractAddon(
+        compressedFilePath,
+        extractedworkspaceFolder,
+        extractedVersionFolder
+      );
+      expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;
+      expect(fs.existsSync(extractedVersionFolder)).to.be.true;
+      expect(fs.existsSync(compressedFilePath)).to.be.false;
+      const fileStats = fs.statSync(
+        path.resolve(extractedVersionFolder, "test.txt")
+      );
+      expect(fileStats.mode).to.equal(0o100444);
 
       const fileContent = fs.readFileSync(
         path.resolve(extractedVersionFolder, "test.txt"),
         "utf-8"
       );
-      expect(fileContent).to.equal("replace me");
-    }
+      expect(fileContent).to.equal("test data inside txt");
+    });
+
+    it("should not overwrite an existing addon", async () => {
+      if (!fs.existsSync(workspaceFolder)) {
+        fs.mkdirSync(workspaceFolder);
+      }
+
+      await createXPI();
+
+      fs.mkdirSync(extractedworkspaceFolder);
+      fs.mkdirSync(extractedVersionFolder);
+
+      // create a file in the version folder
+      fs.writeFileSync(
+        path.resolve(extractedVersionFolder, "test.txt"),
+        "replace me"
+      );
+
+      // make a stub for the quickpick and force it to say no
+      const stub = sinon.stub();
+      stub.onCall(0).returns("No");
+      sinon.replace(vscode.window, "showQuickPick", stub);
+
+      try {
+        await extractAddon(
+          compressedFilePath,
+          extractedworkspaceFolder,
+          extractedVersionFolder
+        );
+        expect(false).to.be.true;
+      } catch (e: any) {
+        expect(e.message).to.equal("Extraction cancelled");
+        expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;
+        expect(fs.existsSync(extractedVersionFolder)).to.be.true;
+        expect(fs.existsSync(compressedFilePath)).to.be.false;
+
+        const fileContent = fs.readFileSync(
+          path.resolve(extractedVersionFolder, "test.txt"),
+          "utf-8"
+        );
+        expect(fileContent).to.equal("replace me");
+      }
+    });
+
+    it("should error if the user cancels the vscode error", async () => {
+      if (!fs.existsSync(workspaceFolder)) {
+        fs.mkdirSync(workspaceFolder);
+      }
+
+      await createXPI();
+
+      const stub = sinon.stub(fs, "existsSync");
+      stub.returns(false);
+
+      const stub2 = sinon.stub(vscode.window, "showErrorMessage");
+      stub2.onCall(0).resolves({ title: "Cancel" });
+
+      try {
+        await extractAddon(
+          compressedFilePath,
+          extractedworkspaceFolder,
+          extractedVersionFolder
+        );
+        expect(false).to.be.true;
+      } catch (e: any) {
+        expect(e.message).to.equal("Extraction failed");
+      }
+    });
+
+    it("should restart the process if the user selects to", async () => {
+      if (!fs.existsSync(workspaceFolder)) {
+        fs.mkdirSync(workspaceFolder);
+      }
+
+      await createXPI();
+
+      const stub = sinon.stub(fs, "existsSync");
+      stub.returns(false);
+
+      const stub2 = sinon.stub(vscode.window, "showErrorMessage");
+      stub2.onCall(0).resolves({ title: "Fetch New Addon" });
+
+      sinon.stub(vscode.commands, "executeCommand").returns(Promise.resolve());
+      try {
+        await extractAddon(
+          compressedFilePath,
+          extractedworkspaceFolder,
+          extractedVersionFolder
+        );
+      } catch (e: any) {
+        expect(e.message).to.equal("Process restarted");
+      }
+    });
+
+    it("should try again if the user selects to", async () => {
+      if (!fs.existsSync(workspaceFolder)) {
+        fs.mkdirSync(workspaceFolder);
+      }
+
+      await createXPI();
+
+      const stub = sinon.stub(vscode.window, "showErrorMessage");
+      stub.onCall(0).resolves({ title: "Try Again" });
+
+      const stub2 = sinon.stub(fs, "existsSync");
+      stub2.onCall(2).returns(false);
+      stub2.onCall(3).returns(true);
+      stub2.onCall(4).returns(true);
+      stub2.onCall(5).returns(true);
+      stub2.onCall(6).returns(true);
+
+      // make a stub for the quickpick and force it to say yes
+      const stub3 = sinon.stub(vscode.window, "showQuickPick");
+      stub3.resolves({ label: "Yes" });
+
+      const stub4 = sinon.stub(fs, "unlinkSync");
+      stub4.returns();
+
+      await extractAddon(
+        compressedFilePath,
+        extractedworkspaceFolder,
+        extractedVersionFolder
+      );
+      sinon.restore();
+      expect(stub.calledOnce).to.be.true;
+      expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;
+      expect(fs.existsSync(extractedVersionFolder)).to.be.true;
+    });
+  });
+
+  describe("dirExistsOrMake()", async () => {
+    it("should create a directory if it does not exist", async () => {
+      if (!fs.existsSync(workspaceFolder)) {
+        fs.mkdirSync(workspaceFolder);
+      }
+
+      const res = dirExistsOrMake(extractedworkspaceFolder);
+      expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;
+      expect(res).to.be.true;
+    });
+
+    it("should not create a directory if it exists", async () => {
+      if (!fs.existsSync(workspaceFolder)) {
+        fs.mkdirSync(workspaceFolder);
+      }
+
+      fs.mkdirSync(extractedworkspaceFolder);
+
+      const res = dirExistsOrMake(extractedworkspaceFolder);
+      expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;
+      expect(res).to.be.undefined;
+    });
   });
 });

--- a/src/test/suite/utils/AddonExtract.test.ts
+++ b/src/test/suite/utils/AddonExtract.test.ts
@@ -1,5 +1,4 @@
 import { expect } from "chai";
-import exp = require("constants");
 import * as fs from "fs";
 import * as jszip from "jszip";
 import { afterEach, describe, it } from "mocha";

--- a/src/test/suite/utils/AddonInfo.test.ts
+++ b/src/test/suite/utils/AddonInfo.test.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { afterEach, describe, it } from "mocha";
 import * as fetch from "node-fetch";
 import * as sinon from "sinon";
+import * as vscode from "vscode";
 
 import { addonInfoResponse } from "../../../amo/types";
 import { getAddonInfo } from "../../../amo/utils/addonInfo";
@@ -88,6 +89,9 @@ describe("AddonInfo.ts", () => {
       json: () => expected,
     });
     sinon.replace(fetch, "default", stub as any);
+
+    const stub2 = sinon.stub(vscode.window, "showErrorMessage");
+    stub2.resolves({ title: "Cancel" });
 
     try {
       await getAddonInfo(input);

--- a/src/test/suite/utils/AddonInfo.test.ts
+++ b/src/test/suite/utils/AddonInfo.test.ts
@@ -35,6 +35,7 @@ describe("AddonInfo.ts", () => {
     const input = "test-addon";
     const stub = sinon.stub();
     stub.resolves({
+      ok: true,
       json: () => expected,
     });
     sinon.replace(fetch, "default", stub as any);
@@ -51,6 +52,7 @@ describe("AddonInfo.ts", () => {
     const stub = sinon.stub();
     stub.resolves({
       json: () => expected,
+      ok: true,
     });
     sinon.replace(fetch, "default", stub as any);
 
@@ -66,6 +68,7 @@ describe("AddonInfo.ts", () => {
     const stub = sinon.stub();
     stub.resolves({
       json: () => expected,
+      ok: true,
     });
     sinon.replace(fetch, "default", stub as any);
 
@@ -78,6 +81,18 @@ describe("AddonInfo.ts", () => {
   });
 
   it("should throw an error if the response is not ok", async () => {
-    expect(true).to.be.true; // TODO
+    const input = "test-addon";
+    const stub = sinon.stub();
+    stub.resolves({
+      ok: false,
+      json: () => expected,
+    });
+    sinon.replace(fetch, "default", stub as any);
+
+    try {
+      await getAddonInfo(input);
+    } catch (e: any) {
+      expect(e.message).to.equal("Failed to fetch addon info");
+    }
   });
 });

--- a/src/test/suite/utils/addonVersions.test.ts
+++ b/src/test/suite/utils/addonVersions.test.ts
@@ -47,7 +47,7 @@ describe("addonVersions.ts", () => {
     });
   }
 
-  describe("getVersionChoice", () => {
+  describe("getVersionChoice()", () => {
     it("should choose a version from the input slug", async () => {
       const stub = sinon.stub();
       stub.onCall(0).returns({
@@ -68,16 +68,19 @@ describe("addonVersions.ts", () => {
         expect(version?.version).to.equal("1");
       });
     });
+  });
 
-    it("should paginate if there are more than 25 versions", async () => {
+  describe("getPaginatedVersions()", () => {
+    it("should retrieve the next page if there is one", async () => {
       const stub = sinon.stub();
       stub.onCall(0).returns({
         json: () => {
           return {
             results: versions,
-            next: `${constants.apiBaseURL}addons/addon/versions/?page=2`,
+            next: "next-page-url",
           };
         },
+        ok: true,
       });
       stub.onCall(1).returns({
         json: () => {
@@ -85,21 +88,61 @@ describe("addonVersions.ts", () => {
             results: versions2,
           };
         },
+        ok: true,
+      });
+
+      sinon.replace(fetch, "default", stub as any);
+
+      const json = await getAddonVersions("addon-slug-or-guid");
+      expect(json.results).to.be.an("array");
+      expect(json.results).to.have.lengthOf(25);
+      expect(json.next).to.be.a("string");
+
+      const json2 = await getAddonVersions("addon-slug-or-guid", json.next);
+      expect(json2.results).to.be.an("array");
+      expect(json2.results).to.have.lengthOf(5);
+      expect(json2.next).to.be.undefined;
+    });
+
+    it("should cancel if the user cancels the prompt", async () => {
+      const stub = sinon.stub();
+      stub.onCall(0).returns({
+        ok: false,
       });
       sinon.replace(fetch, "default", stub as any);
 
-      const stub2 = sinon.stub();
-      stub2.onCall(0).returns("More");
-      stub2.onCall(1).returns("26");
-      sinon.replace(vscode.window, "showQuickPick", stub2);
+      const stub2 = sinon.stub(vscode.window, "showErrorMessage");
+      stub2.onCall(0).resolves({ title: "Cancel" });
 
-      getVersionChoice("addon-slug-or-guid").then((version) => {
-        expect(version?.fileID).to.equal("26");
-        expect(version?.version).to.equal("26");
-      });
+      try {
+        await getAddonVersions("addon-slug-or-guid", "next-page-url");
+        expect(true).to.equal(false);
+      } catch (e: any) {
+        expect(e.message).to.equal("Failed to fetch versions");
+      }
     });
 
-    it("should error if no addon does not exist", async () => {
+    it("should restart the process if the user chooses to", async () => {
+      const stub = sinon.stub();
+      stub.onCall(0).returns({
+        ok: false,
+      });
+      sinon.replace(fetch, "default", stub as any);
+
+      const stub2 = sinon.stub(vscode.window, "showErrorMessage");
+      stub2.onCall(0).resolves({ title: "Fetch New Addon" });
+
+      sinon.stub(vscode.commands, "executeCommand").resolves();
+
+      try {
+        await getAddonVersions("addon-slug-or-guid", "next-page-url");
+        expect(false).to.be.true;
+      } catch (e: any) {
+        expect(e.message).to.equal("Process restarted");
+      }
+    });
+
+    it("should try again if the user chooses to", async () => {
       const stub = sinon.stub();
       stub.onCall(0).returns({
         json: () => {
@@ -108,22 +151,26 @@ describe("addonVersions.ts", () => {
           };
         },
       });
+      stub.onCall(1).returns({
+        json: () => {
+          return {
+            results: versions,
+          };
+        },
+        ok: true,
+      });
       sinon.replace(fetch, "default", stub as any);
 
-      const stub2 = sinon.stub();
-      stub2.onCall(0).returns("");
-      sinon.replace(vscode.window, "showQuickPick", stub2);
+      const stub2 = sinon.stub(vscode.window, "showErrorMessage");
+      stub2.onCall(0).resolves({ title: "Try Again" });
 
-      try {
-        await getVersionChoice("addon-slug-or-guid");
-        expect.fail("Should have thrown an error");
-      } catch (e: any) {
-        expect(e.message).to.equal("Failed to fetch addon");
-      }
+      const res = await getAddonVersions("addon-slug-or-guid", "next-page-url");
+      expect(res.results).to.be.an("array");
+      expect(res.results).to.have.lengthOf(25);
     });
   });
 
-  describe("getAddonVersions", () => {
+  describe("getFirstVersions()", () => {
     it("should return a json if the input is a link", async () => {
       const stub = sinon.stub();
       stub.onCall(0).returns({
@@ -162,37 +209,77 @@ describe("addonVersions.ts", () => {
       expect(json.results).to.have.lengthOf(25);
     });
 
-    it("should retrieve the next page if there is one", async () => {
+    it("should error if user cancels the error", async () => {
       const stub = sinon.stub();
       stub.onCall(0).returns({
         json: () => {
           return {
             results: versions,
-            next: "next-page-url",
           };
         },
-        ok: true,
+      });
+      sinon.replace(fetch, "default", stub as any);
+
+      const stub2 = sinon.stub(vscode.window, "showErrorMessage");
+      stub2.onCall(0).resolves({ title: "Cancel" });
+
+      try {
+        await getAddonVersions("addon-slug-or-guid");
+        expect(false).to.be.true;
+      } catch (e: any) {
+        expect(e.message).to.equal("Failed to fetch addon");
+      }
+    });
+
+    it("should restart if the user chooses to", async () => {
+      const stub = sinon.stub();
+      stub.onCall(0).returns({
+        json: () => {
+          return {
+            results: versions,
+          };
+        },
+      });
+      sinon.replace(fetch, "default", stub as any);
+
+      const stub2 = sinon.stub(vscode.window, "showErrorMessage");
+      stub2.onCall(0).resolves({ title: "Fetch New Addon" });
+
+      sinon.stub(vscode.commands, "executeCommand").resolves();
+
+      try {
+        await getAddonVersions("addon-slug-or-guid");
+        expect(false).to.be.true;
+      } catch (e: any) {
+        expect(e.message).to.equal("Process restarted");
+      }
+    });
+
+    it("should try again if the user chooses to", async () => {
+      const stub = sinon.stub();
+      stub.onCall(0).returns({
+        json: () => {
+          return {
+            results: versions,
+          };
+        },
       });
       stub.onCall(1).returns({
         json: () => {
           return {
-            results: versions2,
+            results: versions,
           };
         },
         ok: true,
       });
-
       sinon.replace(fetch, "default", stub as any);
 
-      const json = await getAddonVersions("addon-slug-or-guid");
-      expect(json.results).to.be.an("array");
-      expect(json.results).to.have.lengthOf(25);
-      expect(json.next).to.be.a("string");
+      const stub2 = sinon.stub(vscode.window, "showErrorMessage");
+      stub2.onCall(0).resolves({ title: "Try Again" });
 
-      const json2 = await getAddonVersions("addon-slug-or-guid", json.next);
-      expect(json2.results).to.be.an("array");
-      expect(json2.results).to.have.lengthOf(5);
-      expect(json2.next).to.be.undefined;
+      const res = await getAddonVersions("addon-slug-or-guid");
+      expect(res.results).to.be.an("array");
+      expect(res.results).to.have.lengthOf(25);
     });
   });
 });

--- a/src/test/suite/utils/addonVersions.test.ts
+++ b/src/test/suite/utils/addonVersions.test.ts
@@ -1,5 +1,4 @@
 import { expect } from "chai";
-import exp = require("constants");
 import { afterEach, describe, it } from "mocha";
 import * as fetch from "node-fetch";
 import * as sinon from "sinon";
@@ -100,7 +99,7 @@ describe("addonVersions.ts", () => {
       });
     });
 
-    it("should error if no version is selected", async () => {
+    it("should error if no addon does not exist", async () => {
       const stub = sinon.stub();
       stub.onCall(0).returns({
         json: () => {
@@ -119,7 +118,7 @@ describe("addonVersions.ts", () => {
         await getVersionChoice("addon-slug-or-guid");
         expect.fail("Should have thrown an error");
       } catch (e: any) {
-        expect(e.message).to.equal("No version choice selected");
+        expect(e.message).to.equal("Failed to fetch addon");
       }
     });
   });
@@ -133,6 +132,7 @@ describe("addonVersions.ts", () => {
             results: versions,
           };
         },
+        ok: true,
       });
 
       sinon.replace(fetch, "default", stub as any);
@@ -152,6 +152,7 @@ describe("addonVersions.ts", () => {
             results: versions,
           };
         },
+        ok: true,
       });
 
       sinon.replace(fetch, "default", stub as any);
@@ -170,6 +171,7 @@ describe("addonVersions.ts", () => {
             next: "next-page-url",
           };
         },
+        ok: true,
       });
       stub.onCall(1).returns({
         json: () => {
@@ -177,6 +179,7 @@ describe("addonVersions.ts", () => {
             results: versions2,
           };
         },
+        ok: true,
       });
 
       sinon.replace(fetch, "default", stub as any);


### PR DESCRIPTION
(excludes `updateTaskbar.ts` due to cache branch)

No more do we check for random undefineds and check the same thing multiple times. Some errors are handled by asking the user if they want to try again, restart the process, or cancel altogether. These were all added to the tests (painstakingly). Some test formats changed and made more efficient (shared resources among tests).

Currently, all errors are caught in the `downloadAndExtract` try/catch since these functions all work in one process only. This function also became impossible to mock (still am unable to mock user-made functions properly), so some of it remains "untested" (each piece is already tested separately)

[Jira](https://mozilla-hub.atlassian.net/browse/AOP-116)