### PR TITLE
Implement authentication.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@types/request": "^2.48.8",
         "extract-zip": "^2.0.1",
         "jszip": "^3.10.1",
+        "keytar": "^7.9.0",
         "pretest": "^1.1.0",
         "test": "^3.3.0"
       },
@@ -18,6 +19,7 @@
         "@types/chai": "^4.3.5",
         "@types/glob": "^8.1.0",
         "@types/jsonwebtoken": "^9.0.2",
+        "@types/keytar": "^4.4.2",
         "@types/mocha": "^10.0.1",
         "@types/node": "16.x",
         "@types/node-fetch": "^2.6.4",
@@ -426,6 +428,16 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/keytar": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@types/keytar/-/keytar-4.4.2.tgz",
+      "integrity": "sha512-xtQcDj9ruGnMwvSu1E2BH4SFa5Dv2PvSPd0CKEBLN5hEj/v5YpXJY+B6hAfuKIbvEomD7vJTc/P1s1xPNh2kRw==",
+      "deprecated": "This is a stub types definition. keytar provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "keytar": "*"
       }
     },
     "node_modules/@types/minimatch": {
@@ -1270,6 +1282,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1542,6 +1600,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -1729,6 +1792,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -1739,6 +1816,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -1767,6 +1852,14 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -2383,6 +2476,14 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2601,6 +2702,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2719,6 +2825,11 @@
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/glob": {
       "version": "8.1.0",
@@ -3118,6 +3229,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
@@ -3653,6 +3769,16 @@
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
     },
+    "node_modules/keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -3753,7 +3879,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3838,6 +3963,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3857,6 +3993,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mocha": {
       "version": "10.2.0",
@@ -3989,6 +4130,11 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4028,6 +4174,22 @@
       "dependencies": {
         "type-detect": "4.0.8"
       }
+    },
+    "node_modules/node-abi": {
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.45.0.tgz",
+      "integrity": "sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.11",
@@ -4383,6 +4545,31 @@
       "hasInstallScript": true,
       "peer": true
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4501,6 +4688,28 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {
@@ -4806,7 +5015,6 @@
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
       "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4882,6 +5090,49 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/sinon": {
       "version": "15.1.0",
@@ -5119,6 +5370,45 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/terser": {
@@ -5837,8 +6127,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "extract-zip": "^2.0.1",
         "jsonwebtoken": "^9.0.1",
         "jszip": "^3.10.1",
-        "keytar": "^7.9.0",
         "pretest": "^1.1.0",
         "test": "^3.3.0"
       },
@@ -20,7 +19,6 @@
         "@types/chai": "^4.3.5",
         "@types/glob": "^8.1.0",
         "@types/jsonwebtoken": "^9.0.2",
-        "@types/keytar": "^4.4.2",
         "@types/mocha": "^10.0.1",
         "@types/node": "16.x",
         "@types/node-fetch": "^2.6.4",
@@ -429,16 +427,6 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/keytar": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@types/keytar/-/keytar-4.4.2.tgz",
-      "integrity": "sha512-xtQcDj9ruGnMwvSu1E2BH4SFa5Dv2PvSPd0CKEBLN5hEj/v5YpXJY+B6hAfuKIbvEomD7vJTc/P1s1xPNh2kRw==",
-      "deprecated": "This is a stub types definition. keytar provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "keytar": "*"
       }
     },
     "node_modules/@types/minimatch": {
@@ -1283,52 +1271,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/bl/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1606,11 +1548,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -1798,20 +1735,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -1822,14 +1745,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -1858,14 +1773,6 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/diff": {
@@ -2490,14 +2397,6 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2716,11 +2615,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2839,11 +2733,6 @@
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/glob": {
       "version": "8.1.0",
@@ -3243,11 +3132,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
@@ -3817,16 +3701,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/keytar": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
-      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-addon-api": "^4.3.0",
-        "prebuild-install": "^7.0.1"
-      }
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -4011,17 +3885,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4041,11 +3904,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mocha": {
       "version": "10.2.0",
@@ -4178,11 +4036,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4222,22 +4075,6 @@
       "dependencies": {
         "type-detect": "4.0.8"
       }
-    },
-    "node_modules/node-abi": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.45.0.tgz",
-      "integrity": "sha512-iwXuFrMAcFVi/ZoZiqq8BzAdsLw9kxDfTC0HMyjXfSL/6CSDAGD5UmR7azrAgWV1zKYq7dUUMj4owusBWKLsiQ==",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.11",
@@ -4593,31 +4430,6 @@
       "hasInstallScript": true,
       "peer": true
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4736,28 +4548,6 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {
@@ -5139,49 +4929,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/sinon": {
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.1.0.tgz",
@@ -5418,45 +5165,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/terser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@types/chai": "^4.3.5",
         "@types/glob": "^8.1.0",
+        "@types/jsonwebtoken": "^9.0.2",
         "@types/mocha": "^10.0.1",
         "@types/node": "16.x",
         "@types/node-fetch": "^2.6.4",
@@ -417,6 +418,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@types/request": "^2.48.8",
         "extract-zip": "^2.0.1",
+        "jsonwebtoken": "^9.0.1",
         "jszip": "^3.10.1",
         "keytar": "^7.9.0",
         "pretest": "^1.1.0",
@@ -1419,6 +1420,11 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1902,6 +1908,14 @@
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3738,6 +3752,21 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+      "integrity": "sha512-K8wx7eJ5TPvEjuiVSkv167EVboBDv9PZdDoF7BgeQnBLVvZWW9clr2PsQHVJDTKaEIH5JBIwHujGcHp7GgI2eg==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash": "^4.17.21",
+        "ms": "^2.1.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jsprim": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
@@ -3768,6 +3797,25 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/keytar": {
       "version": "7.9.0",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   "dependencies": {
     "@types/request": "^2.48.8",
     "extract-zip": "^2.0.1",
+    "jsonwebtoken": "^9.0.1",
     "jszip": "^3.10.1",
     "keytar": "^7.9.0",
     "pretest": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/chai": "^4.3.5",
     "@types/glob": "^8.1.0",
     "@types/jsonwebtoken": "^9.0.2",
+    "@types/keytar": "^4.4.2",
     "@types/mocha": "^10.0.1",
     "@types/node": "16.x",
     "@types/node-fetch": "^2.6.4",
@@ -91,6 +92,7 @@
     "@types/request": "^2.48.8",
     "extract-zip": "^2.0.1",
     "jszip": "^3.10.1",
+    "keytar": "^7.9.0",
     "pretest": "^1.1.0",
     "test": "^3.3.0"
   }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@types/chai": "^4.3.5",
     "@types/glob": "^8.1.0",
     "@types/jsonwebtoken": "^9.0.2",
-    "@types/keytar": "^4.4.2",
     "@types/mocha": "^10.0.1",
     "@types/node": "16.x",
     "@types/node-fetch": "^2.6.4",
@@ -93,7 +92,6 @@
     "extract-zip": "^2.0.1",
     "jsonwebtoken": "^9.0.1",
     "jszip": "^3.10.1",
-    "keytar": "^7.9.0",
     "pretest": "^1.1.0",
     "test": "^3.3.0"
   }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@types/chai": "^4.3.5",
     "@types/glob": "^8.1.0",
+    "@types/jsonwebtoken": "^9.0.2",
     "@types/mocha": "^10.0.1",
     "@types/node": "16.x",
     "@types/node-fetch": "^2.6.4",

--- a/src/amo/commands/getApiCreds.ts
+++ b/src/amo/commands/getApiCreds.ts
@@ -1,0 +1,46 @@
+import * as keytar from "keytar";
+import * as vscode from "vscode";
+
+export async function getApiKeyFromUser() {
+  const apiKey = await vscode.window.showInputBox({
+    prompt:
+      "Enter your AMO API Key (IE: user:12345678:123)",
+    title: "AMO API Key",
+  });
+
+  if (!apiKey) {
+    throw new Error("No API Key provided");
+  }
+
+  await keytar.setPassword("assay", "amoApiKey", apiKey);
+}
+
+export async function getSecretFromUser() {
+  const apiSecret = await vscode.window.showInputBox({
+    prompt:
+      "Enter your AMO API Secret",
+    title: "AMO API Secret",
+    password: true,
+  });
+
+  if (!apiSecret) {
+    throw new Error("No API Secret provided");
+  }
+
+  await keytar.setPassword("assay", "amoApiSecret", apiSecret);
+}
+
+export async function getCredsFromStorage() {
+  const apiKey = await keytar.getPassword("assay", "amoApiKey");
+  const secret = await keytar.getPassword("assay", "amoApiSecret");
+
+  if (!apiKey) {
+    await getApiKeyFromUser();
+    return getCredsFromStorage();
+  } else if (!secret) {
+    await getSecretFromUser();
+    return getCredsFromStorage();
+  }
+  
+  return { apiKey, secret };
+}

--- a/src/amo/commands/getApiCreds.ts
+++ b/src/amo/commands/getApiCreds.ts
@@ -5,7 +5,7 @@ import { showErrorMessage } from "../utils/processErrors";
 
 export async function getApiKeyFromUser() {
   const apiKey = await vscode.window.showInputBox({
-    prompt: "Enter your AMO API Key (IE: user:12345678:123)",
+    prompt: "Enter your AMO API Key (e.g. user:12345678:123)",
     title: "AMO API Key",
   });
 

--- a/src/amo/commands/getApiCreds.ts
+++ b/src/amo/commands/getApiCreds.ts
@@ -3,8 +3,7 @@ import * as vscode from "vscode";
 
 export async function getApiKeyFromUser() {
   const apiKey = await vscode.window.showInputBox({
-    prompt:
-      "Enter your AMO API Key (IE: user:12345678:123)",
+    prompt: "Enter your AMO API Key (IE: user:12345678:123)",
     title: "AMO API Key",
   });
 
@@ -17,8 +16,7 @@ export async function getApiKeyFromUser() {
 
 export async function getSecretFromUser() {
   const apiSecret = await vscode.window.showInputBox({
-    prompt:
-      "Enter your AMO API Secret",
+    prompt: "Enter your AMO API Secret",
     title: "AMO API Secret",
     password: true,
   });
@@ -30,17 +28,20 @@ export async function getSecretFromUser() {
   await keytar.setPassword("assay", "amoApiSecret", apiSecret);
 }
 
-export async function getCredsFromStorage() {
+export async function getCredsFromStorage(): Promise<{
+  apiKey: string;
+  secret: string;
+}> {
   const apiKey = await keytar.getPassword("assay", "amoApiKey");
   const secret = await keytar.getPassword("assay", "amoApiSecret");
 
   if (!apiKey) {
     await getApiKeyFromUser();
-    return getCredsFromStorage();
+    return await getCredsFromStorage();
   } else if (!secret) {
     await getSecretFromUser();
-    return getCredsFromStorage();
+    return await getCredsFromStorage();
   }
-  
+
   return { apiKey, secret };
 }

--- a/src/amo/commands/getApiCreds.ts
+++ b/src/amo/commands/getApiCreds.ts
@@ -1,6 +1,6 @@
-import * as keytar from "keytar";
 import * as vscode from "vscode";
 
+import { getExtensionSecretStorage } from "../../config/globals";
 import { showErrorMessage } from "../utils/processErrors";
 
 export async function getApiKeyFromUser() {
@@ -13,7 +13,9 @@ export async function getApiKeyFromUser() {
     throw new Error("No API Key provided");
   }
 
-  await keytar.setPassword("assay", "amoApiKey", apiKey);
+  const secrets = getExtensionSecretStorage();
+
+  await secrets.store("amoApiKey", apiKey);
   return true;
 }
 
@@ -28,7 +30,8 @@ export async function getSecretFromUser() {
     throw new Error("No API Secret provided");
   }
 
-  await keytar.setPassword("assay", "amoApiSecret", apiSecret);
+  const secrets = getExtensionSecretStorage();
+  await secrets.store("amoApiSecret", apiSecret);
   return true;
 }
 
@@ -36,11 +39,12 @@ export async function getCredsFromStorage(): Promise<{
   apiKey: string;
   secret: string;
 }> {
-  const apiKey = await keytar.getPassword("assay", "amoApiKey");
-  const secret = await keytar.getPassword("assay", "amoApiSecret");
+  const secrets = getExtensionSecretStorage();
+  const apiKey = await secrets.get("amoApiKey");
+  const secret = await secrets.get("amoApiSecret");
 
   if (!apiKey || !secret) {
-    await showErrorMessage(
+    return await showErrorMessage(
       {
         window: {
           other: "No API Key or Secret found",
@@ -52,7 +56,6 @@ export async function getCredsFromStorage(): Promise<{
       "other",
       getCredsFromStorage
     );
-    return { apiKey: "", secret: "" };
   }
 
   return { apiKey, secret };

--- a/src/amo/extension.ts
+++ b/src/amo/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 
 import { downloadAndExtract } from "./commands/getAddon";
+import { getApiKeyFromUser, getSecretFromUser } from "./commands/getApiCreds";
 import { updateTaskbar } from "./commands/updateTaskbar";
 import { AssayTreeDataProvider } from "./views/sidebarView";
 import { WelcomeView } from "./views/welcomeView";
@@ -18,6 +19,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
   vscode.commands.registerCommand("assay.get", () => {
     downloadAndExtract(storagePath);
+  });
+
+  vscode.commands.registerCommand("assay.getApiKey", () => {
+    getApiKeyFromUser();
+  });
+
+  vscode.commands.registerCommand("assay.getSecret", () => {
+    getSecretFromUser();
   });
 
   const sidebar = vscode.window.createTreeView("assayCommands", {

--- a/src/amo/extension.ts
+++ b/src/amo/extension.ts
@@ -5,9 +5,11 @@ import { getApiKeyFromUser, getSecretFromUser } from "./commands/getApiCreds";
 import { updateTaskbar } from "./commands/updateTaskbar";
 import { AssayTreeDataProvider } from "./views/sidebarView";
 import { WelcomeView } from "./views/welcomeView";
+import { setExtensionSecretStorage } from "../config/globals";
 
 export async function activate(context: vscode.ExtensionContext) {
   const storagePath: string = context.globalStorageUri.fsPath;
+  setExtensionSecretStorage(context.secrets);
 
   vscode.commands.registerCommand("assay.review", async function (url: string) {
     vscode.env.openExternal(vscode.Uri.parse(url));

--- a/src/amo/types.ts
+++ b/src/amo/types.ts
@@ -33,3 +33,12 @@ export type configConstants = {
   reviewBaseURL: string;
   downloadBaseURL: string;
 };
+
+export type errorMessages = {
+  window: {
+    [code: string]: string;
+  };
+  thrown: {
+    [code: string]: string;
+  };
+};

--- a/src/amo/utils/addonDownload.ts
+++ b/src/amo/utils/addonDownload.ts
@@ -14,10 +14,10 @@ async function fetchDownloadFile(fileId: string) {
   if (!response.ok) {
     const errorMessages: errorMessages = {
       window: {
-        404: `(Status ${response.status}): Addon download file not found`,
-        401: `(Status ${response.status}): Unauthorized request for download file`,
-        403: `(Status ${response.status}): Forbidden request for download file`,
-        other: `(Status ${response.status}): Could not fetch download file`,
+        404: `(Status ${response.status}): XPI download file not found`,
+        401: `(Status ${response.status}): Unauthorized request for XPI file`,
+        403: `(Status ${response.status}): Inadequate permissions for XPI file`,
+        other: `(Status ${response.status}): Could not fetch XPI file`,
       },
       thrown: {
         404: "Download file not found",

--- a/src/amo/utils/addonDownload.ts
+++ b/src/amo/utils/addonDownload.ts
@@ -11,7 +11,6 @@ async function fetchDownloadFile(fileId: string) {
   const headers = await makeAuthHeader();
   const response = await fetch(url, { headers });
   if (!response.ok) {
-    console.log(response);
     await showErrorMessage(
       `(Status ${response.status}): Could not fetch addon info.`,
       "Request failed",

--- a/src/amo/utils/addonDownload.ts
+++ b/src/amo/utils/addonDownload.ts
@@ -3,12 +3,15 @@ import fetch from "node-fetch";
 import * as vscode from "vscode";
 
 import { showErrorMessage } from "./processErrors";
+import { makeAuthHeader } from "./requestAuth";
 import constants from "../../config/config";
 
 async function fetchDownloadFile(fileId: string) {
   const url = `${constants.downloadBaseURL}${fileId}`;
-  const response = await fetch(url);
+  const headers = await makeAuthHeader();
+  const response = await fetch(url, { headers });
   if (!response.ok) {
+    console.log(response);
     await showErrorMessage(
       `(Status ${response.status}): Could not fetch addon info.`,
       "Request failed",

--- a/src/amo/utils/addonDownload.ts
+++ b/src/amo/utils/addonDownload.ts
@@ -5,18 +5,31 @@ import * as vscode from "vscode";
 import { showErrorMessage } from "./processErrors";
 import { makeAuthHeader } from "./requestAuth";
 import constants from "../../config/config";
+import { errorMessages } from "../types";
 
 async function fetchDownloadFile(fileId: string) {
   const url = `${constants.downloadBaseURL}${fileId}`;
   const headers = await makeAuthHeader();
   const response = await fetch(url, { headers });
   if (!response.ok) {
-    await showErrorMessage(
-      `(Status ${response.status}): Could not fetch addon info.`,
-      "Request failed",
-      fetchDownloadFile,
-      [fileId]
-    );
+    const errorMessages: errorMessages = {
+      window: {
+        404: `(Status ${response.status}): Addon download file not found`,
+        401: `(Status ${response.status}): Unauthorized request for download file`,
+        403: `(Status ${response.status}): Forbidden request for download file`,
+        other: `(Status ${response.status}): Could not fetch download file`,
+      },
+      thrown: {
+        404: "Download file not found",
+        401: "Unauthorized request",
+        403: "Forbidden request",
+        other: "Download request failed",
+      },
+    };
+
+    await showErrorMessage(errorMessages, response.status, fetchDownloadFile, [
+      fileId,
+    ]);
   }
   return response;
 }
@@ -34,12 +47,19 @@ export async function downloadAddon(fileId: string, path: string) {
       dest.close();
 
       if (!fs.existsSync(path)) {
-        await showErrorMessage(
-          `Could not download addon to ${path}.`,
-          "Download failed",
-          downloadAddon,
-          [fileId, path]
-        );
+        const errorMessages: errorMessages = {
+          window: {
+            other: `Could not download addon to ${path}`,
+          },
+          thrown: {
+            other: "Download failed",
+          },
+        };
+
+        await showErrorMessage(errorMessages, "other", downloadAddon, [
+          fileId,
+          path,
+        ]);
       }
     }
   );

--- a/src/amo/utils/addonExtract.ts
+++ b/src/amo/utils/addonExtract.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as vscode from "vscode";
 
 import { showErrorMessage } from "./processErrors";
+import { errorMessages } from "../types";
 
 export async function dirExistsOrMake(dir: string) {
   if (!fs.existsSync(dir)) {
@@ -35,12 +36,20 @@ export async function extractAddon(
   await fs.promises.unlink(compressedFilePath); // remove xpi
 
   if (!fs.existsSync(addonVersionFolderPath)) {
-    await showErrorMessage(
-      `Extraction failed. Could not find ${addonVersionFolderPath}`,
-      "Extraction failed",
-      extractAddon,
-      [compressedFilePath, addonFolderPath, addonVersionFolderPath]
-    );
+    const errorMessages: errorMessages = {
+      window: {
+        other: `Extraction failed. Could not find ${addonVersionFolderPath}`,
+      },
+      thrown: {
+        other: "Extraction failed",
+      },
+    };
+
+    await showErrorMessage(errorMessages, "other", extractAddon, [
+      compressedFilePath,
+      addonFolderPath,
+      addonVersionFolderPath,
+    ]);
   }
 
   vscode.window.showInformationMessage("Extraction complete");

--- a/src/amo/utils/addonInfo.ts
+++ b/src/amo/utils/addonInfo.ts
@@ -1,7 +1,7 @@
 import fetch from "node-fetch";
-import * as vscode from "vscode";
 
 import { showErrorMessage } from "./processErrors";
+import { makeAuthHeader } from "./requestAuth";
 import constants from "../../config/config";
 import { addonInfoResponse } from "../types";
 
@@ -10,7 +10,9 @@ export async function getAddonInfo(input: string): Promise<addonInfoResponse> {
     ? input.split("addon/")[1].split("/")[0]
     : input;
   const url = `${constants.apiBaseURL}addons/addon/${slug}`;
-  const response = await fetch(url);
+  const headers = await makeAuthHeader();
+
+  const response = await fetch(url, { headers: headers });
   if (!response.ok) {
     await showErrorMessage(
       `(Status ${response.status}): Could not fetch addon info.`,
@@ -20,5 +22,6 @@ export async function getAddonInfo(input: string): Promise<addonInfoResponse> {
     );
   }
   const json = await response.json();
+  console.log(json);
   return json;
 }

--- a/src/amo/utils/addonInfo.ts
+++ b/src/amo/utils/addonInfo.ts
@@ -3,7 +3,7 @@ import fetch from "node-fetch";
 import { showErrorMessage } from "./processErrors";
 import { makeAuthHeader } from "./requestAuth";
 import constants from "../../config/config";
-import { addonInfoResponse } from "../types";
+import { addonInfoResponse, errorMessages } from "../types";
 
 export async function getAddonInfo(input: string): Promise<addonInfoResponse> {
   const slug: string = input.includes("/")
@@ -14,12 +14,24 @@ export async function getAddonInfo(input: string): Promise<addonInfoResponse> {
 
   const response = await fetch(url, { headers: headers });
   if (!response.ok) {
-    await showErrorMessage(
-      `(Status ${response.status}): Could not fetch addon info.`,
-      "Failed to fetch addon info",
-      getAddonInfo,
-      [input]
-    );
+    const errorMessages: errorMessages = {
+      window: {
+        404: `(Status ${response.status}): Addon not found`,
+        401: `(Status ${response.status}): Unauthorized request`,
+        403: `(Status ${response.status}): Forbidden request`,
+        other: `(Status ${response.status}): Could not fetch addon info`,
+      },
+      thrown: {
+        404: "Failed to fetch addon info",
+        401: "Unauthorized request",
+        403: "Forbidden request",
+        other: "Failed to fetch addon info",
+      },
+    };
+
+    await showErrorMessage(errorMessages, response.status, getAddonInfo, [
+      input,
+    ]);
   }
   const json = await response.json();
   return json;

--- a/src/amo/utils/addonInfo.ts
+++ b/src/amo/utils/addonInfo.ts
@@ -22,6 +22,5 @@ export async function getAddonInfo(input: string): Promise<addonInfoResponse> {
     );
   }
   const json = await response.json();
-  console.log(json);
   return json;
 }

--- a/src/amo/utils/addonInfo.ts
+++ b/src/amo/utils/addonInfo.ts
@@ -18,7 +18,7 @@ export async function getAddonInfo(input: string): Promise<addonInfoResponse> {
       window: {
         404: `(Status ${response.status}): Addon not found`,
         401: `(Status ${response.status}): Unauthorized request`,
-        403: `(Status ${response.status}): Forbidden request`,
+        403: `(Status ${response.status}): Inadequate permissions`,
         other: `(Status ${response.status}): Could not fetch addon info`,
       },
       thrown: {

--- a/src/amo/utils/addonVersions.ts
+++ b/src/amo/utils/addonVersions.ts
@@ -15,11 +15,9 @@ export async function getAddonVersions(input: string, next?: string) {
     : `${constants.apiBaseURL}addons/addon/${slug}/versions?filter=all_with_unlisted`;
 
   const headers = await makeAuthHeader();
-
   const response = await fetch(url, { headers });
 
   if (!response.ok) {
-    console.log(response.json());
     const errMsgWindow = next
       ? "Could not fetch more versions"
       : `Addon ${slug} not found`;

--- a/src/amo/utils/addonVersions.ts
+++ b/src/amo/utils/addonVersions.ts
@@ -2,6 +2,7 @@ import fetch from "node-fetch";
 import * as vscode from "vscode";
 
 import { showErrorMessage } from "./processErrors";
+import { makeAuthHeader } from "./requestAuth";
 import constants from "../../config/config";
 import { addonVersion } from "../types";
 
@@ -11,10 +12,14 @@ export async function getAddonVersions(input: string, next?: string) {
     : input;
   const url = next
     ? next
-    : `${constants.apiBaseURL}addons/addon/${slug}/versions/`;
-  const response = await fetch(url);
+    : `${constants.apiBaseURL}addons/addon/${slug}/versions?filter=all_with_unlisted`;
+
+  const headers = await makeAuthHeader();
+
+  const response = await fetch(url, { headers });
 
   if (!response.ok) {
+    console.log(response.json());
     const errMsgWindow = next
       ? "Could not fetch more versions"
       : `Addon ${slug} not found`;

--- a/src/amo/utils/addonVersions.ts
+++ b/src/amo/utils/addonVersions.ts
@@ -12,7 +12,7 @@ export async function getAddonVersions(input: string, next?: string) {
     : input;
   const url = next
     ? next
-    : `${constants.apiBaseURL}addons/addon/${slug}/versions?filter=all_with_unlisted`;
+    : `${constants.apiBaseURL}addons/addon/${slug}/versions?filter=all_with_deleted`;
 
   const headers = await makeAuthHeader();
   const response = await fetch(url, { headers });
@@ -24,7 +24,7 @@ export async function getAddonVersions(input: string, next?: string) {
           ? `(Status ${response.status}): "Could not fetch more versions"`
           : `(Status ${response.status}): Addon not found`,
         401: `(Status ${response.status}): Unauthorized request`,
-        403: `(Status ${response.status}): Forbidden request`,
+        403: `(Status ${response.status}): Inadequate permissions`,
         other: `(Status ${response.status}): Could not fetch versions`,
       },
       thrown: {

--- a/src/amo/utils/processErrors.ts
+++ b/src/amo/utils/processErrors.ts
@@ -15,7 +15,7 @@ export async function showErrorMessage(
   const cancelMessage =
     errorMessages.thrown[status] || errorMessages.thrown.other;
 
-  await vscode.window
+  return await vscode.window
     .showErrorMessage(
       message,
       { modal: true },

--- a/src/amo/utils/processErrors.ts
+++ b/src/amo/utils/processErrors.ts
@@ -1,13 +1,19 @@
 import * as vscode from "vscode";
 
+import { errorMessages } from "../types";
+
 export async function showErrorMessage(
-  message: string,
-  cancelMessage: string,
+  errorMessages: errorMessages,
+  status: keyof errorMessages["window"] | keyof errorMessages["thrown"],
   tryAgainFunction: (...args: any[]) => Promise<any>,
   tryAgainFunctionParams?: any[]
 ) {
   const tryAgainButton = { title: "Try Again" };
   const fetchNewAddonButton = { title: "Fetch New Addon" };
+
+  const message = errorMessages.window[status] || errorMessages.window.other;
+  const cancelMessage =
+    errorMessages.thrown[status] || errorMessages.thrown.other;
 
   await vscode.window
     .showErrorMessage(

--- a/src/amo/utils/requestAuth.ts
+++ b/src/amo/utils/requestAuth.ts
@@ -1,0 +1,23 @@
+import * as jwt from "jsonwebtoken";
+
+import { getCredsFromStorage } from "../commands/getApiCreds";
+
+// as per https://addons-server.readthedocs.io/en/latest/topics/api/auth.html
+export async function makeToken() {
+  const { apiKey, secret } = await getCredsFromStorage();
+
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const payload = {
+    iss: apiKey,
+    jti: Math.random().toString(),
+    iat: issuedAt,
+    exp: issuedAt + 60,
+  };
+
+  return jwt.sign(payload, secret, { algorithm: "HS256" });
+}
+
+export async function makeAuthHeader() {
+  const token = await makeToken();
+  return { Authorization: `JWT ${token}` };
+}

--- a/src/amo/views/sidebarView.ts
+++ b/src/amo/views/sidebarView.ts
@@ -34,6 +34,22 @@ export class AssayTreeDataProvider
           }
         ),
         new AssayTreeItem(
+          "Enter API Key",
+          vscode.TreeItemCollapsibleState.None,
+          {
+            command: "assay.getApiKey",
+            title: "Enter AMO API Key",
+          }
+        ),
+        new AssayTreeItem(
+          "Enter API Secret",
+          vscode.TreeItemCollapsibleState.None,
+          {
+            command: "assay.getSecret",
+            title: "Enter AMO API Secret",
+          }
+        ),
+        new AssayTreeItem(
           "View Documentation",
           vscode.TreeItemCollapsibleState.None,
           {

--- a/src/config/globals.ts
+++ b/src/config/globals.ts
@@ -1,0 +1,11 @@
+import { SecretStorage } from "vscode";
+
+let secrets: SecretStorage;
+
+export function setExtensionSecretStorage(secretStorage: SecretStorage) {
+  secrets = secretStorage;
+}
+
+export function getExtensionSecretStorage(): SecretStorage {
+  return secrets;
+}

--- a/src/test/suite/commands/getApiCreds.test.ts
+++ b/src/test/suite/commands/getApiCreds.test.ts
@@ -1,0 +1,86 @@
+import { expect } from "chai";
+import * as keytar from "keytar";
+import { describe, it, afterEach, beforeEach } from "mocha";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+
+import {
+  getCredsFromStorage,
+  getApiKeyFromUser,
+  getSecretFromUser,
+} from "../../../amo/commands/getApiCreds";
+
+describe("getApiCreds.ts", async () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  beforeEach(() => {
+    const setPasswordStub = sinon.stub(keytar, "setPassword");
+    setPasswordStub.resolves();
+  });
+
+  describe("getCredsFromStorage()", () => {
+    it("should return the creds if they exist", async () => {
+      const keytarGetPasswordStub = sinon.stub(keytar, "getPassword");
+      keytarGetPasswordStub.resolves("test");
+      const result = await getCredsFromStorage();
+      expect(result.apiKey).to.equal("test");
+      expect(result.secret).to.equal("test");
+    });
+
+    it("should error if the creds don't exist", async () => {
+      const keytarGetPasswordStub = sinon.stub(keytar, "getPassword");
+      keytarGetPasswordStub.resolves(undefined);
+      const errorMessageWindowStub = sinon.stub(
+        vscode.window,
+        "showErrorMessage"
+      );
+      errorMessageWindowStub.resolves({ title: "Cancel" });
+      try {
+        await getCredsFromStorage();
+      } catch (error: any) {
+        expect(error.message).to.equal("No API Key or Secret found");
+      }
+    });
+  });
+
+  describe("getApiKeyFromUser()", () => {
+    it("should return true the input is provided", async () => {
+      const inputBoxStub = sinon.stub(vscode.window, "showInputBox");
+      inputBoxStub.onFirstCall().resolves("test");
+      const result = await getApiKeyFromUser();
+      expect(result).to.be.true;
+    });
+
+    it("should raise an error if no input is provided", async () => {
+      const inputBoxStub = sinon.stub(vscode.window, "showInputBox");
+      inputBoxStub.onFirstCall().resolves(undefined);
+      try {
+        await getApiKeyFromUser();
+      } catch (error: any) {
+        expect(error.message).to.equal("No API Key provided");
+      }
+    });
+  });
+
+  describe("getSecretFromUser()", () => {
+    it("should return true if the input is provided", async () => {
+      const inputBoxStub = sinon.stub(vscode.window, "showInputBox");
+      inputBoxStub.onFirstCall().resolves("test");
+
+      const result = await getSecretFromUser();
+      expect(result).to.be.true;
+    });
+
+    it("should raise an error if no input is provided", async () => {
+      const inputBoxStub = sinon.stub(vscode.window, "showInputBox");
+      inputBoxStub.onFirstCall().resolves(undefined);
+      try {
+        await getSecretFromUser();
+      } catch (error: any) {
+        expect(error.message).to.equal("No API Secret provided");
+      }
+    });
+  });
+});

--- a/src/test/suite/commands/getApiCreds.test.ts
+++ b/src/test/suite/commands/getApiCreds.test.ts
@@ -1,5 +1,4 @@
 import { expect } from "chai";
-import * as keytar from "keytar";
 import { describe, it, afterEach, beforeEach } from "mocha";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
@@ -9,6 +8,7 @@ import {
   getApiKeyFromUser,
   getSecretFromUser,
 } from "../../../amo/commands/getApiCreds";
+import * as authUtils from "../../../config/globals";
 
 describe("getApiCreds.ts", async () => {
   afterEach(() => {
@@ -16,22 +16,56 @@ describe("getApiCreds.ts", async () => {
   });
 
   beforeEach(() => {
-    const setPasswordStub = sinon.stub(keytar, "setPassword");
-    setPasswordStub.resolves();
+    const secretsStub = sinon.stub(authUtils, "getExtensionSecretStorage");
+    secretsStub.returns({
+      get: async () => {
+        return "test";
+      },
+      store: async () => {
+        return;
+      },
+      delete: function (key: string): Thenable<void> {
+        throw new Error("Function not implemented.");
+      },
+      onDidChange: function (
+        listener: (e: vscode.SecretStorageChangeEvent) => any,
+        thisArgs?: any,
+        disposables?: vscode.Disposable[] | undefined
+      ): vscode.Disposable {
+        throw new Error("Function not implemented.");
+      },
+    });
   });
 
   describe("getCredsFromStorage()", () => {
     it("should return the creds if they exist", async () => {
-      const keytarGetPasswordStub = sinon.stub(keytar, "getPassword");
-      keytarGetPasswordStub.resolves("test");
       const result = await getCredsFromStorage();
       expect(result.apiKey).to.equal("test");
       expect(result.secret).to.equal("test");
     });
 
     it("should error if the creds don't exist", async () => {
-      const keytarGetPasswordStub = sinon.stub(keytar, "getPassword");
-      keytarGetPasswordStub.resolves(undefined);
+      // update the get of secretstub to return undefined
+      sinon.restore();
+      const secretsStub = sinon.stub(authUtils, "getExtensionSecretStorage");
+      secretsStub.returns({
+        get: async () => {
+          return undefined;
+        },
+        store: async () => {
+          return;
+        },
+        delete: function (key: string): Thenable<void> {
+          throw new Error("Function not implemented.");
+        },
+        onDidChange: function (
+          listener: (e: vscode.SecretStorageChangeEvent) => any,
+          thisArgs?: any,
+          disposables?: vscode.Disposable[] | undefined
+        ): vscode.Disposable {
+          throw new Error("Function not implemented.");
+        },
+      });
       const errorMessageWindowStub = sinon.stub(
         vscode.window,
         "showErrorMessage"

--- a/src/test/suite/utils/AddonDownload.test.ts
+++ b/src/test/suite/utils/AddonDownload.test.ts
@@ -1,22 +1,28 @@
 import { expect } from "chai";
 import * as fs from "fs";
-import { afterEach, describe, it } from "mocha";
+import { afterEach, describe, it, beforeEach } from "mocha";
 import * as fetch from "node-fetch";
 import path = require("path");
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 
 import { downloadAddon } from "../../../amo/utils/addonDownload";
+import * as authUtils from "../../../amo/utils/requestAuth";
 import constants from "../../../config/config";
 
 describe("addonDownload.ts", async () => {
   const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
 
-  afterEach(() => {
+  afterEach(async () => {
     sinon.restore();
     if (fs.existsSync(workspaceFolder)) {
-      fs.rmSync(workspaceFolder, { recursive: true });
+      await fs.promises.rm(workspaceFolder, { recursive: true });
     }
+  });
+
+  beforeEach(() => {
+    const authStub = sinon.stub(authUtils, "makeAuthHeader");
+    authStub.resolves({ Authorization: "test" });
   });
 
   const badResponse = {

--- a/src/test/suite/utils/AddonDownload.test.ts
+++ b/src/test/suite/utils/AddonDownload.test.ts
@@ -85,7 +85,7 @@ describe("addonDownload.ts", async () => {
       await downloadAddon(addonId, downloadedFilePath);
       expect(false).to.be.true;
     } catch (e: any) {
-      expect(e.message).to.equal("Request failed");
+      expect(e.message).to.equal("Download request failed");
       expect(stub.calledOnce).to.be.true;
       expect(stub.calledWith(`${constants.downloadBaseURL}${addonId}`)).to.be
         .true;

--- a/src/test/suite/utils/AddonInfo.test.ts
+++ b/src/test/suite/utils/AddonInfo.test.ts
@@ -1,16 +1,22 @@
 import { expect } from "chai";
-import { afterEach, describe, it } from "mocha";
+import { afterEach, describe, it, beforeEach } from "mocha";
 import * as fetch from "node-fetch";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 
 import { addonInfoResponse } from "../../../amo/types";
 import { getAddonInfo } from "../../../amo/utils/addonInfo";
+import * as authUtils from "../../../amo/utils/requestAuth";
 import constants from "../../../config/config";
 
 describe("AddonInfo.ts", () => {
   afterEach(() => {
     sinon.restore();
+  });
+
+  beforeEach(() => {
+    const authStub = sinon.stub(authUtils, "makeAuthHeader");
+    authStub.resolves({ Authorization: "test" });
   });
 
   const expected: addonInfoResponse = {

--- a/src/test/suite/utils/addonVersions.test.ts
+++ b/src/test/suite/utils/addonVersions.test.ts
@@ -156,6 +156,8 @@ describe("addonVersions.ts", () => {
             results: versions,
           };
         },
+        ok: false,
+        status: 404,
       });
       stub.onCall(1).returns({
         json: () => {
@@ -232,7 +234,7 @@ describe("addonVersions.ts", () => {
         await getAddonVersions("addon-slug-or-guid");
         expect(false).to.be.true;
       } catch (e: any) {
-        expect(e.message).to.equal("Failed to fetch addon");
+        expect(e.message).to.equal("Failed to fetch versions");
       }
     });
 

--- a/src/test/suite/utils/addonVersions.test.ts
+++ b/src/test/suite/utils/addonVersions.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { afterEach, describe, it } from "mocha";
+import { afterEach, describe, it, beforeEach } from "mocha";
 import * as fetch from "node-fetch";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
@@ -9,11 +9,17 @@ import {
   getAddonVersions,
   getVersionChoice,
 } from "../../../amo/utils/addonVersions";
+import * as authUtils from "../../../amo/utils/requestAuth";
 import constants from "../../../config/config";
 
 describe("addonVersions.ts", () => {
   afterEach(() => {
     sinon.restore();
+  });
+
+  beforeEach(() => {
+    const authStub = sinon.stub(authUtils, "makeAuthHeader");
+    authStub.resolves({ Authorization: "test" });
   });
 
   const versions: addonVersion[] = [];

--- a/src/test/suite/utils/requestAuth.test.ts
+++ b/src/test/suite/utils/requestAuth.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
-import { describe, it, afterEach, beforeEach } from "mocha";
+import { describe, it, afterEach } from "mocha";
 import * as sinon from "sinon";
-import * as vscode from "vscode";
 
 import * as credUtils from "../../../amo/commands/getApiCreds";
 import { makeToken, makeAuthHeader } from "../../../amo/utils/requestAuth";

--- a/src/test/suite/utils/requestAuth.test.ts
+++ b/src/test/suite/utils/requestAuth.test.ts
@@ -1,0 +1,40 @@
+import { expect } from "chai";
+import { describe, it, afterEach, beforeEach } from "mocha";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+
+import * as credUtils from "../../../amo/commands/getApiCreds";
+import { makeToken, makeAuthHeader } from "../../../amo/utils/requestAuth";
+
+describe("requestAuth.ts", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("makeToken()", () => {
+    it("should return the token", async () => {
+      const creds = {
+        apiKey: "test",
+        secret: "test",
+      };
+      const getCredsStub = sinon.stub(credUtils, "getCredsFromStorage");
+      getCredsStub.resolves(creds);
+      const result = await makeToken();
+      expect(result).to.be.a("string");
+    });
+  });
+
+  describe("makeAuthHeader()", () => {
+    it("should return the auth header", async () => {
+      const creds = {
+        apiKey: "test",
+        secret: "test",
+      };
+      const getCredsStub = sinon.stub(credUtils, "getCredsFromStorage");
+      getCredsStub.resolves(creds);
+      const result = await makeAuthHeader();
+      // expect it to have a key called authorization
+      expect(result).to.have.property("Authorization");
+    });
+  });
+});

--- a/src/test/suite/views/sidebarView.test.ts
+++ b/src/test/suite/views/sidebarView.test.ts
@@ -18,9 +18,9 @@ describe("sidebarView.ts", () => {
 
     const tabChildren = await sidebarView.getChildren(tab);
     expect(tabChildren).to.be.an("array");
-    expect(tabChildren).to.have.lengthOf(2);
+    expect(tabChildren).to.have.lengthOf(4);
     expect(tabChildren[0].label).to.equal("Review New Addon Version");
-    expect(tabChildren[1].label).to.equal("View Documentation");
+    expect(tabChildren[3].label).to.equal("View Documentation");
   });
 
   it("should get the tree item", async () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,8 +21,9 @@ const extensionConfig = {
     libraryTarget: 'commonjs2'
   },
   externals: {
-    vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+    vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     // modules added here also need to be added in the .vscodeignore file
+    keytar: 'commonjs keytar'
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,6 @@ const extensionConfig = {
   externals: {
     vscode: 'commonjs vscode', // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     // modules added here also need to be added in the .vscodeignore file
-    keytar: 'commonjs keytar'
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader


### PR DESCRIPTION
This PR allows the user to input their key and secret in (stored with keytar) to fetch and download unlisted addons. Since we now have error messages to do with auth, I updated how they are made as well.

The key and secret input boxes are accessible from the sidebar. Ideally, they are asked on the fly when fetching an addon. However, the vscode input box api does not stay focused when clicking off the screen. This means the user cannot go and copy their code then come back without ending the process.

The `showErrorMessage` function takes in an object of the possible responses depending on the status of the response (tried to cut down on the amount of if branches there are).

The requests ask for the unlisted addon versions (filter=all_with_unlisted). Should they also ask for the deleted versions? The server code (`addons-server/src/olympia/addons/views.py:AddonVersionViewSet:check_permissions`) doesn't seem to allow both to show up in one request?

Finally, keytar gave me issues when trying to import it, and the solution was to have it as an external module in the webpack. This gave me _some_ problems with the CI tests since my systems and the CI system would not error at the same things. 