### PR TITLE
Fix up tests

### DIFF
--- a/src/utils/addonDownload.ts
+++ b/src/utils/addonDownload.ts
@@ -27,9 +27,12 @@ async function fetchDownloadFile(fileId: string) {
       },
     };
 
-    await showErrorMessage(errorMessages, response.status, fetchDownloadFile, [
-      fileId,
-    ]);
+    return await showErrorMessage(
+      errorMessages,
+      response.status,
+      fetchDownloadFile,
+      [fileId]
+    );
   }
   return response;
 }
@@ -56,7 +59,7 @@ export async function downloadAddon(fileId: string, path: string) {
           },
         };
 
-        await showErrorMessage(errorMessages, "other", downloadAddon, [
+        return await showErrorMessage(errorMessages, "other", downloadAddon, [
           fileId,
           path,
         ]);

--- a/src/utils/addonExtract.ts
+++ b/src/utils/addonExtract.ts
@@ -45,7 +45,7 @@ export async function extractAddon(
       },
     };
 
-    await showErrorMessage(errorMessages, "other", extractAddon, [
+    return await showErrorMessage(errorMessages, "other", extractAddon, [
       compressedFilePath,
       addonFolderPath,
       addonVersionFolderPath,

--- a/src/utils/addonInfo.ts
+++ b/src/utils/addonInfo.ts
@@ -29,9 +29,12 @@ export async function getAddonInfo(input: string): Promise<addonInfoResponse> {
       },
     };
 
-    await showErrorMessage(errorMessages, response.status, getAddonInfo, [
-      input,
-    ]);
+    return await showErrorMessage(
+      errorMessages,
+      response.status,
+      getAddonInfo,
+      [input]
+    );
   }
   const json = await response.json();
   return json;

--- a/src/utils/addonVersions.ts
+++ b/src/utils/addonVersions.ts
@@ -35,10 +35,12 @@ export async function getAddonVersions(input: string, next?: string) {
       },
     };
 
-    await showErrorMessage(errorMessages, response.status, getAddonVersions, [
-      input,
-      next,
-    ]);
+    return await showErrorMessage(
+      errorMessages,
+      response.status,
+      getAddonVersions,
+      [input, next]
+    );
   }
   const json = await response.json();
   return json;

--- a/test/suite/commands/getAddon.test.ts
+++ b/test/suite/commands/getAddon.test.ts
@@ -12,15 +12,15 @@ describe("getAddon.ts", async () => {
 
   describe("getInput()", () => {
     it("should return the input if provided", async () => {
-      const stub = sinon.stub(vscode.window, "showInputBox");
-      stub.onFirstCall().resolves("test");
+      const showInputBoxStub = sinon.stub(vscode.window, "showInputBox");
+      showInputBoxStub.onFirstCall().resolves("test");
       const result = await getInput();
       expect(result).to.equal("test");
     });
 
     it("should raise an error if no input is provided", async () => {
-      const stub = sinon.stub(vscode.window, "showInputBox");
-      stub.onFirstCall().resolves(undefined);
+      const showInputBoxStub = sinon.stub(vscode.window, "showInputBox");
+      showInputBoxStub.onFirstCall().resolves(undefined);
       try {
         await getInput();
       } catch (error) {

--- a/test/suite/commands/updateTaskbar.test.ts
+++ b/test/suite/commands/updateTaskbar.test.ts
@@ -7,55 +7,62 @@ import * as vscode from "vscode";
 import { updateTaskbar } from "../../../src/commands/updateTaskbar";
 import { setExtensionStoragePath } from "../../../src/config/globals";
 
+const guid = "emailguid@guid.com";
+
+const fakeActiveEditor = {
+  document: {
+    uri: {
+      fsPath: "/test",
+    },
+  },
+};
+
+const fakeActiveEditorWithGuid = {
+  document: {
+    uri: {
+      fsPath: `/root/${guid}/version/test.js`,
+    },
+  },
+};
+
+const fakeWorkspaceFolder = {
+  uri: {
+    fsPath: "/root",
+  },
+};
+
 describe("updateTaskbar.ts", async () => {
   afterEach(() => {
     sinon.restore();
   });
 
-  const guid = "emailguid@guid.com";
-
-  const fakeActiveEditor = {
-    document: {
-      uri: {
-        fsPath: "/test",
-      },
-    },
-  };
-
-  const fakeActiveEditor2 = {
-    document: {
-      uri: {
-        fsPath: `/root/${guid}/version/test.js`,
-      },
-    },
-  };
-
-  const fakeWorkspaceFolder = {
-    uri: {
-      fsPath: "/root",
-    },
-  };
-
-  describe("updateTaskbar", () => {
+  describe("updateTaskbar()", () => {
     it("should return undefined if there is no activeTextEditor", async () => {
       // by default, vscode.window.activeTextEditor is undefined
       expect(await updateTaskbar()).to.be.undefined;
     });
 
     it("should throw error if the folder is not in the root", async () => {
-      const stub = sinon.stub(vscode.workspace, "getConfiguration");
-      stub.returns({
+      const getConfigurationStub = sinon.stub(
+        vscode.workspace,
+        "getConfiguration"
+      );
+      getConfigurationStub.returns({
         get: () => {
           return "/test";
         },
       } as any);
 
-      const stub2 = sinon.stub();
-      stub2.returns(fakeActiveEditor2);
-      sinon.replaceGetter(vscode.window, "activeTextEditor", stub2 as any);
+      const activeTextEditorStub = sinon.stub();
+      activeTextEditorStub.returns(fakeActiveEditorWithGuid);
+      sinon.replaceGetter(
+        vscode.window,
+        "activeTextEditor",
+        activeTextEditorStub as any
+      );
 
-      const stub3 = sinon.stub(fs, "existsSync");
-      stub3.returns(true);
+      const existsSyncStub = sinon.stub(fs, "existsSync");
+      existsSyncStub.returns(true);
 
       try {
         await updateTaskbar();
@@ -66,19 +73,26 @@ describe("updateTaskbar.ts", async () => {
     });
 
     it("should throw an error if there is no guid in the path", async () => {
-      const stub = sinon.stub(vscode.workspace, "getConfiguration");
-      stub.returns({
+      const getConfigurationStub = sinon.stub(
+        vscode.workspace,
+        "getConfiguration"
+      );
+      getConfigurationStub.returns({
         get: () => {
           return "/test";
         },
       } as any);
 
-      const stub2 = sinon.stub();
-      stub2.returns(fakeActiveEditor);
-      sinon.replaceGetter(vscode.window, "activeTextEditor", stub2 as any);
+      const activeTextEditorStub = sinon.stub();
+      activeTextEditorStub.returns(fakeActiveEditor);
+      sinon.replaceGetter(
+        vscode.window,
+        "activeTextEditor",
+        activeTextEditorStub as any
+      );
 
-      const stub3 = sinon.stub(fs, "existsSync");
-      stub3.returns(true);
+      const existsSyncStub = sinon.stub(fs, "existsSync");
+      existsSyncStub.returns(true);
 
       try {
         await updateTaskbar();
@@ -89,26 +103,37 @@ describe("updateTaskbar.ts", async () => {
     });
 
     it("should return true if the taskbar is updated", async () => {
-      const stub = sinon.stub(vscode.workspace, "getConfiguration");
-      stub.returns({
+      const getConfigurationStub = sinon.stub(
+        vscode.workspace,
+        "getConfiguration"
+      );
+      getConfigurationStub.returns({
         get: () => {
           return "/root";
         },
       } as any);
 
-      const stub2 = sinon.stub();
-      stub2.returns(fakeActiveEditor2);
-      sinon.replaceGetter(vscode.window, "activeTextEditor", stub2 as any);
+      const activeTextEditorStub = sinon.stub();
+      activeTextEditorStub.returns(fakeActiveEditorWithGuid);
+      sinon.replaceGetter(
+        vscode.window,
+        "activeTextEditor",
+        activeTextEditorStub as any
+      );
 
-      const stub3 = sinon.stub(fs, "existsSync");
-      stub3.returns(true);
+      const existsSyncStub = sinon.stub(fs, "existsSync");
+      existsSyncStub.returns(true);
 
-      const stub4 = sinon.stub();
-      stub4.returns(fakeWorkspaceFolder);
-      sinon.replaceGetter(vscode.workspace, "workspaceFolders", stub4 as any);
+      const workspaceFoldersStub = sinon.stub();
+      workspaceFoldersStub.returns(fakeWorkspaceFolder);
+      sinon.replaceGetter(
+        vscode.workspace,
+        "workspaceFolders",
+        workspaceFoldersStub as any
+      );
 
-      const stub5 = sinon.stub(fs.promises, "readFile");
-      stub5.resolves(`{"reviewUrl":"test"}`);
+      const readFileStub = sinon.stub(fs.promises, "readFile");
+      readFileStub.resolves(`{"reviewUrl":"test"}`);
 
       setExtensionStoragePath("");
 

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -4,12 +4,12 @@ import * as vscode from "vscode";
 
 import { activate, deactivate } from "../../src/extension";
 
-describe("extension.ts", () => {
-  const context = {
-    subscriptions: [] as vscode.Disposable[],
-    globalStorageUri: vscode.Uri.parse("test"),
-  } as vscode.ExtensionContext;
+const context = {
+  subscriptions: [] as vscode.Disposable[],
+  globalStorageUri: vscode.Uri.parse("test"),
+} as vscode.ExtensionContext;
 
+describe("extension.ts", () => {
   it("should activate and register commands and have 3 subscriptions", async () => {
     await activate(context);
     const commands = await vscode.commands.getCommands(true);

--- a/test/suite/utils/AddonDownload.test.ts
+++ b/test/suite/utils/AddonDownload.test.ts
@@ -10,212 +10,98 @@ import { downloadAddon } from "../../../src//utils/addonDownload";
 import constants from "../../../src/config/config";
 import * as authUtils from "../../../src/utils/requestAuth";
 
+const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
+
+const badResponse = {
+  ok: false,
+  buffer: () => {
+    return "test data";
+  },
+};
+
+const goodResponse = {
+  ok: true,
+  buffer: () => {
+    return "test data";
+  },
+};
+
+const addonId = "123456";
+const addonSlug = "test-addon";
+const downloadedFilePath = path.resolve(workspaceFolder, `${addonSlug}.xpi`);
+
 describe("addonDownload.ts", async () => {
-  const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
+  beforeEach(() => {
+    const authStub = sinon.stub(authUtils, "makeAuthHeader");
+    authStub.resolves({ Authorization: "test" });
+    if (!fs.existsSync(workspaceFolder)) {
+      fs.mkdirSync(workspaceFolder);
+    }
+  });
 
   afterEach(async () => {
     sinon.restore();
     if (fs.existsSync(workspaceFolder)) {
       await fs.promises.rm(workspaceFolder, { recursive: true });
     }
+    if (fs.existsSync(downloadedFilePath)) {
+      await fs.promises.rm(downloadedFilePath, { recursive: true });
+    }
   });
-
-  beforeEach(() => {
-    const authStub = sinon.stub(authUtils, "makeAuthHeader");
-    authStub.resolves({ Authorization: "test" });
-  });
-
-  const badResponse = {
-    ok: false,
-    buffer: () => {
-      return "test data";
-    },
-  };
-
-  const goodResponse = {
-    ok: true,
-    buffer: () => {
-      return "test data";
-    },
-  };
-
-  const addonId = "123456";
-  const addonSlug = "test-addon";
-  const downloadedFilePath = path.resolve(workspaceFolder, `${addonSlug}.xpi`);
 
   it("should download the xpi of the addon", async () => {
-    if (!fs.existsSync(workspaceFolder)) {
-      fs.mkdirSync(workspaceFolder);
-    }
+    const fetchStub = sinon.stub();
+    fetchStub.resolves(goodResponse);
+    sinon.replace(fetch, "default", fetchStub as any);
 
-    const stub = sinon.stub();
-    stub.resolves(goodResponse);
-    sinon.replace(fetch, "default", stub as any);
-
-    const stub2 = sinon.stub(fs, "existsSync");
-    stub2.onFirstCall().returns(true);
+    const existsSyncStub = sinon.stub(fs, "existsSync");
+    existsSyncStub.onFirstCall().returns(true);
 
     await downloadAddon(addonId, downloadedFilePath);
     sinon.restore();
 
-    expect(stub.calledOnce).to.be.true;
-    expect(stub.calledWith(`${constants.downloadBaseURL}${addonId}`)).to.be
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(fetchStub.calledWith(`${constants.downloadBaseURL}${addonId}`)).to.be
       .true;
 
     // wait for file to be written (there should be a better way to do this)
     await new Promise((resolve) => setTimeout(resolve, 200));
     expect(fs.existsSync(downloadedFilePath)).to.be.true;
-
-    fs.rmSync(downloadedFilePath, { recursive: true });
   });
 
   it("should not make a file if the request failed", async () => {
-    if (!fs.existsSync(workspaceFolder)) {
-      fs.mkdirSync(workspaceFolder);
-    }
+    const fetchStub = sinon.stub();
+    fetchStub.resolves(badResponse);
+    sinon.replace(fetch, "default", fetchStub as any);
 
-    const stub = sinon.stub();
-    stub.resolves(badResponse);
-    sinon.replace(fetch, "default", stub as any);
-
-    const stub2 = sinon.stub(vscode.window, "showErrorMessage");
-    stub2.resolves({ title: "Cancel" });
+    const showErrorMessageStub = sinon.stub(vscode.window, "showErrorMessage");
+    showErrorMessageStub.resolves({ title: "Cancel" });
 
     try {
       await downloadAddon(addonId, downloadedFilePath);
       expect(false).to.be.true;
     } catch (e: any) {
       expect(e.message).to.equal("Download request failed");
-      expect(stub.calledOnce).to.be.true;
-      expect(stub.calledWith(`${constants.downloadBaseURL}${addonId}`)).to.be
-        .true;
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.calledWith(`${constants.downloadBaseURL}${addonId}`)).to
+        .be.true;
 
       await new Promise((resolve) => setTimeout(resolve, 200));
       expect(fs.existsSync(downloadedFilePath)).to.be.false;
     }
   });
 
-  it("should try again if the request failed", async () => {
-    if (!fs.existsSync(workspaceFolder)) {
-      fs.mkdirSync(workspaceFolder);
-    }
-
-    const stub = sinon.stub();
-    stub.onFirstCall().resolves(badResponse);
-    stub.onSecondCall().resolves(goodResponse);
-    sinon.replace(fetch, "default", stub as any);
-
-    const stub2 = sinon.stub(fs, "existsSync");
-    stub2.onFirstCall().returns(true);
-
-    const stub3 = sinon.stub(vscode.window, "showErrorMessage");
-    stub3.onFirstCall().resolves({ title: "Try Again" });
-
-    await downloadAddon(addonId, downloadedFilePath);
-    expect(stub.calledTwice).to.be.true;
-    expect(stub.calledWith(`${constants.downloadBaseURL}${addonId}`)).to.be
-      .true;
-
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    const exists = await fs.promises
-      .access(downloadedFilePath, fs.constants.F_OK)
-      .then(() => true)
-      .catch(() => false);
-    expect(exists).to.be.true;
-  });
-
-  it("should restart the get process if the user chooses to", async () => {
-    if (!fs.existsSync(workspaceFolder)) {
-      fs.mkdirSync(workspaceFolder);
-    }
-
-    const stub = sinon.stub();
-    stub.onFirstCall().resolves(badResponse);
-    sinon.replace(fetch, "default", stub as any);
-
-    const stub2 = sinon.stub(fs, "existsSync");
-    stub2.onFirstCall().returns(true);
-
-    const stub3 = sinon.stub(vscode.window, "showErrorMessage");
-    stub3.onFirstCall().resolves({ title: "Fetch New Addon" });
-
-    try {
-      await downloadAddon(addonId, downloadedFilePath);
-      expect(false).to.be.true;
-    } catch (e: any) {
-      expect(e.message).to.equal("Process restarted");
-    }
-  });
-
-  it("should try again if the download failed", async () => {
-    if (!fs.existsSync(workspaceFolder)) {
-      fs.mkdirSync(workspaceFolder);
-    }
-
-    const stub = sinon.stub();
-    stub.resolves(goodResponse);
-    sinon.replace(fetch, "default", stub as any);
-
-    const stub2 = sinon.stub(fs, "existsSync");
-    stub2.onFirstCall().returns(false);
-    stub2.onSecondCall().returns(true);
-
-    const stub3 = sinon.stub(vscode.window, "showErrorMessage");
-    stub3.resolves({ title: "Try Again" });
-
-    await downloadAddon(addonId, downloadedFilePath);
-    expect(stub.calledWith(`${constants.downloadBaseURL}${addonId}`)).to.be
-      .true;
-
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    const exists = await fs.promises
-      .access(downloadedFilePath, fs.constants.F_OK)
-      .then(() => true)
-      .catch(() => false);
-    expect(exists).to.be.true;
-  });
-
-  it("should restart the get process if the user chooses to", async () => {
-    if (!fs.existsSync(workspaceFolder)) {
-      fs.mkdirSync(workspaceFolder);
-    }
-
-    const stub = sinon.stub();
-    stub.resolves(goodResponse);
-    sinon.replace(fetch, "default", stub as any);
-
-    const stub2 = sinon.stub(fs, "existsSync");
-    stub2.onFirstCall().returns(false);
-    stub2.onSecondCall().returns(true);
-
-    const stub3 = sinon.stub(vscode.window, "showErrorMessage");
-    stub3.resolves({ title: "Fetch New Addon" });
-
-    sinon.stub(vscode.commands, "executeCommand").returns(Promise.resolve());
-
-    try {
-      await downloadAddon(addonId, downloadedFilePath);
-      expect(false).to.be.true;
-    } catch (e: any) {
-      expect(e.message).to.equal("Process restarted");
-    }
-  });
-
   it("should throw an error if the user cancels", async () => {
-    if (!fs.existsSync(workspaceFolder)) {
-      fs.mkdirSync(workspaceFolder);
-    }
+    const fetchStub = sinon.stub();
+    fetchStub.resolves(goodResponse);
+    sinon.replace(fetch, "default", fetchStub as any);
 
-    const stub = sinon.stub();
-    stub.resolves(goodResponse);
-    sinon.replace(fetch, "default", stub as any);
+    const existsSyncStub = sinon.stub(fs, "existsSync");
+    existsSyncStub.onFirstCall().returns(false);
+    existsSyncStub.onSecondCall().returns(true);
 
-    const stub2 = sinon.stub(fs, "existsSync");
-    stub2.onFirstCall().returns(false);
-    stub2.onSecondCall().returns(true);
-
-    const stub3 = sinon.stub(vscode.window, "showErrorMessage");
-    stub3.resolves({ title: "Cancel" });
+    const showErrorMessageStub = sinon.stub(vscode.window, "showErrorMessage");
+    showErrorMessageStub.resolves({ title: "Cancel" });
 
     try {
       await downloadAddon(addonId, downloadedFilePath);

--- a/test/suite/utils/AddonExtract.test.ts
+++ b/test/suite/utils/AddonExtract.test.ts
@@ -1,16 +1,38 @@
 import { expect } from "chai";
 import * as fs from "fs";
 import * as jszip from "jszip";
-import { afterEach, describe, it } from "mocha";
+import { afterEach, describe, it, beforeEach } from "mocha";
 import path = require("path");
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 
 import { extractAddon, dirExistsOrMake } from "../../../src/utils/addonExtract";
 
+const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
+const compressedFilePath = path.resolve(workspaceFolder, "test-addon.xpi");
+const addonGUID = "test-addon";
+const addonVersion = "1.0.0";
+const extractedworkspaceFolder = path.resolve(workspaceFolder, addonGUID);
+const extractedVersionFolder = path.resolve(
+  extractedworkspaceFolder,
+  addonVersion
+);
+
+async function createXPI() {
+  const zip = new jszip();
+  zip.file("test.txt", "test data inside txt");
+  await zip.generateAsync({ type: "nodebuffer" }).then((content) => {
+    fs.writeFileSync(compressedFilePath, content);
+  });
+}
+
 describe("AddonExtract.ts", async () => {
-  const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
-  const compressedFilePath = path.resolve(workspaceFolder, "test-addon.xpi");
+  beforeEach(async () => {
+    if (!fs.existsSync(workspaceFolder)) {
+      fs.mkdirSync(workspaceFolder);
+    }
+    await createXPI();
+  });
 
   afterEach(() => {
     sinon.restore();
@@ -19,38 +41,18 @@ describe("AddonExtract.ts", async () => {
     }
   });
 
-  async function createXPI() {
-    const zip = new jszip();
-    zip.file("test.txt", "test data inside txt");
-    await zip.generateAsync({ type: "nodebuffer" }).then((content) => {
-      fs.writeFileSync(compressedFilePath, content);
-    });
-  }
-
-  const addonGUID = "test-addon";
-  const addonVersion = "1.0.0";
-  const extractedworkspaceFolder = path.resolve(workspaceFolder, addonGUID);
-  const extractedVersionFolder = path.resolve(
-    extractedworkspaceFolder,
-    addonVersion
-  );
-
   describe("extractAddon()", async () => {
     it("should extract a new addon, remove the xpi, and make files read only", async () => {
-      if (!fs.existsSync(workspaceFolder)) {
-        fs.mkdirSync(workspaceFolder);
-      }
-
-      await createXPI();
-
       await extractAddon(
         compressedFilePath,
         extractedworkspaceFolder,
         extractedVersionFolder
       );
+
       expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;
       expect(fs.existsSync(extractedVersionFolder)).to.be.true;
       expect(fs.existsSync(compressedFilePath)).to.be.false;
+
       const fileStats = fs.statSync(
         path.resolve(extractedVersionFolder, "test.txt")
       );
@@ -58,12 +60,6 @@ describe("AddonExtract.ts", async () => {
     });
 
     it("should overwrite an existing addon", async () => {
-      if (!fs.existsSync(workspaceFolder)) {
-        fs.mkdirSync(workspaceFolder);
-      }
-
-      await createXPI();
-
       fs.mkdirSync(extractedworkspaceFolder);
       fs.mkdirSync(extractedVersionFolder);
 
@@ -74,18 +70,20 @@ describe("AddonExtract.ts", async () => {
       );
 
       // make a stub for the quickpick and force it to say yes
-      const stub = sinon.stub();
-      stub.onCall(0).returns("Yes");
-      sinon.replace(vscode.window, "showQuickPick", stub);
+      const showQuickPickStub = sinon.stub();
+      showQuickPickStub.onCall(0).returns("Yes");
+      sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
       await extractAddon(
         compressedFilePath,
         extractedworkspaceFolder,
         extractedVersionFolder
       );
+
       expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;
       expect(fs.existsSync(extractedVersionFolder)).to.be.true;
       expect(fs.existsSync(compressedFilePath)).to.be.false;
+      
       const fileStats = fs.statSync(
         path.resolve(extractedVersionFolder, "test.txt")
       );
@@ -99,12 +97,6 @@ describe("AddonExtract.ts", async () => {
     });
 
     it("should not overwrite an existing addon", async () => {
-      if (!fs.existsSync(workspaceFolder)) {
-        fs.mkdirSync(workspaceFolder);
-      }
-
-      await createXPI();
-
       fs.mkdirSync(extractedworkspaceFolder);
       fs.mkdirSync(extractedVersionFolder);
 
@@ -115,9 +107,9 @@ describe("AddonExtract.ts", async () => {
       );
 
       // make a stub for the quickpick and force it to say no
-      const stub = sinon.stub();
-      stub.onCall(0).returns("No");
-      sinon.replace(vscode.window, "showQuickPick", stub);
+      const showQuickPickStub = sinon.stub();
+      showQuickPickStub.onCall(0).returns("No");
+      sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
       try {
         await extractAddon(
@@ -164,84 +156,16 @@ describe("AddonExtract.ts", async () => {
         expect(e.message).to.equal("Extraction failed");
       }
     });
-
-    it("should restart the process if the user selects to", async () => {
-      if (!fs.existsSync(workspaceFolder)) {
-        fs.mkdirSync(workspaceFolder);
-      }
-
-      await createXPI();
-
-      const stub = sinon.stub(fs, "existsSync");
-      stub.returns(false);
-
-      const stub2 = sinon.stub(vscode.window, "showErrorMessage");
-      stub2.onCall(0).resolves({ title: "Fetch New Addon" });
-
-      sinon.stub(vscode.commands, "executeCommand").returns(Promise.resolve());
-      try {
-        await extractAddon(
-          compressedFilePath,
-          extractedworkspaceFolder,
-          extractedVersionFolder
-        );
-      } catch (e: any) {
-        expect(e.message).to.equal("Process restarted");
-      }
-    });
-
-    it("should try again if the user selects to", async () => {
-      if (!fs.existsSync(workspaceFolder)) {
-        fs.mkdirSync(workspaceFolder);
-      }
-
-      await createXPI();
-
-      const stub = sinon.stub(vscode.window, "showErrorMessage");
-      stub.onCall(0).resolves({ title: "Try Again" });
-
-      const stub2 = sinon.stub(fs, "existsSync");
-      stub2.onCall(2).returns(false);
-      stub2.onCall(3).returns(true);
-      stub2.onCall(4).returns(true);
-      stub2.onCall(5).returns(true);
-      stub2.onCall(6).returns(true);
-
-      // make a stub for the quickpick and force it to say yes
-      const stub3 = sinon.stub(vscode.window, "showQuickPick");
-      stub3.resolves({ label: "Yes" });
-
-      const stub4 = sinon.stub(fs.promises, "unlink");
-      stub4.resolves();
-
-      await extractAddon(
-        compressedFilePath,
-        extractedworkspaceFolder,
-        extractedVersionFolder
-      );
-      sinon.restore();
-      expect(stub.calledOnce).to.be.true;
-      expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;
-      expect(fs.existsSync(extractedVersionFolder)).to.be.true;
-    });
   });
 
   describe("dirExistsOrMake()", async () => {
     it("should create a directory if it does not exist", async () => {
-      if (!fs.existsSync(workspaceFolder)) {
-        fs.mkdirSync(workspaceFolder);
-      }
-
       const res = await dirExistsOrMake(extractedworkspaceFolder);
       expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;
       expect(res).to.be.true;
     });
 
     it("should not create a directory if it exists", async () => {
-      if (!fs.existsSync(workspaceFolder)) {
-        fs.mkdirSync(workspaceFolder);
-      }
-
       fs.mkdirSync(extractedworkspaceFolder);
 
       const res = await dirExistsOrMake(extractedworkspaceFolder);

--- a/test/suite/utils/AddonInfo.test.ts
+++ b/test/suite/utils/AddonInfo.test.ts
@@ -9,98 +9,101 @@ import { addonInfoResponse } from "../../../src/types";
 import { getAddonInfo } from "../../../src/utils/addonInfo";
 import * as authUtils from "../../../src/utils/requestAuth";
 
-describe("AddonInfo.ts", () => {
-  afterEach(() => {
-    sinon.restore();
-  });
+const addonSlug = "test-addon";
+const addonId = "123456";
+const addonUrl = `https://addons.mozilla.org/en-US/firefox/addon/${addonSlug}`;
+const expected: addonInfoResponse = {
+  slug: addonSlug,
+  name: {
+    en: "Test addon",
+  },
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  current_version: {
+    version: "1.0.0",
+    file: {
+      id: "100100",
+    },
+  },
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  default_locale: "en",
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  review_url: "fakeurl",
+  guid: "guid@firebird.com",
+};
 
+describe("AddonInfo.ts", () => {
   beforeEach(() => {
     const authStub = sinon.stub(authUtils, "makeAuthHeader");
     authStub.resolves({ Authorization: "test" });
   });
 
-  const expected: addonInfoResponse = {
-    slug: "test-addon",
-    name: {
-      en: "Test addon",
-    },
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    current_version: {
-      version: "1.0.0",
-      file: {
-        id: "123456",
-      },
-    },
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    default_locale: "en",
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    review_url: "fakeurl",
-    guid: "gee you eye dee",
-  };
+  afterEach(() => {
+    sinon.restore();
+  });
 
   it("should return a json object of type addonInfoResponse if input is a slug", async () => {
-    const input = "test-addon";
-    const stub = sinon.stub();
-    stub.resolves({
+    const fetchStub = sinon.stub();
+    fetchStub.resolves({
       ok: true,
       json: () => expected,
     });
-    sinon.replace(fetch, "default", stub as any);
+    sinon.replace(fetch, "default", fetchStub as any);
 
-    const actual = await getAddonInfo(input);
+    const actual = await getAddonInfo(addonSlug);
     expect(actual).to.deep.equal(expected);
-    expect(stub.calledOnce).to.be.true;
-    expect(stub.calledWith(`${constants.apiBaseURL}addons/addon/${input}`)).to
-      .be.true;
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(
+      fetchStub.calledWith(`${constants.apiBaseURL}addons/addon/${addonSlug}`)
+    ).to.be.true;
   });
 
   it("should return a json object of type addonInfoResponse if input is an id", async () => {
-    const input = "123456";
-    const stub = sinon.stub();
-    stub.resolves({
+    const fetchStub = sinon.stub();
+    fetchStub.resolves({
       json: () => expected,
       ok: true,
     });
-    sinon.replace(fetch, "default", stub as any);
+    sinon.replace(fetch, "default", fetchStub as any);
 
-    const actual = await getAddonInfo(input);
+    const actual = await getAddonInfo(addonId);
     expect(actual).to.deep.equal(expected);
-    expect(stub.calledOnce).to.be.true;
-    expect(stub.calledWith(`${constants.apiBaseURL}addons/addon/${input}`)).to
-      .be.true;
+    expect(fetchStub.calledOnce).to.be.true;
+    expect(
+      fetchStub.calledWith(`${constants.apiBaseURL}addons/addon/${addonId}`)
+    ).to.be.true;
   });
 
   it("should return a json object of type addonInfoResponse if input is a url", async () => {
-    const input = "https://addons.mozilla.org/en-US/firefox/addon/test-addon";
-    const stub = sinon.stub();
-    stub.resolves({
+    const fetchStub = sinon.stub();
+    fetchStub.resolves({
       json: () => expected,
       ok: true,
     });
-    sinon.replace(fetch, "default", stub as any);
+    sinon.replace(fetch, "default", fetchStub as any);
 
-    const actual = await getAddonInfo(input);
+    const actual = await getAddonInfo(addonUrl);
     expect(actual).to.deep.equal(expected);
-    expect(stub.calledOnce).to.be.true;
+    expect(fetchStub.calledOnce).to.be.true;
     expect(
-      stub.calledWith(`${constants.apiBaseURL}addons/addon/${expected.slug}`)
+      fetchStub.calledWith(
+        `${constants.apiBaseURL}addons/addon/${expected.slug}`
+      )
     ).to.be.true;
   });
 
   it("should throw an error if the response is not ok", async () => {
-    const input = "test-addon";
-    const stub = sinon.stub();
-    stub.resolves({
+    const fetchStub = sinon.stub();
+    fetchStub.resolves({
       ok: false,
       json: () => expected,
     });
-    sinon.replace(fetch, "default", stub as any);
+    sinon.replace(fetch, "default", fetchStub as any);
 
-    const stub2 = sinon.stub(vscode.window, "showErrorMessage");
-    stub2.resolves({ title: "Cancel" });
+    const showErrorMessageStub = sinon.stub(vscode.window, "showErrorMessage");
+    showErrorMessageStub.resolves({ title: "Cancel" });
 
     try {
-      await getAddonInfo(input);
+      await getAddonInfo(addonSlug);
     } catch (e: any) {
       expect(e.message).to.equal("Failed to fetch addon info");
     }

--- a/test/suite/utils/addonCache.test.ts
+++ b/test/suite/utils/addonCache.test.ts
@@ -1,7 +1,8 @@
 import { expect } from "chai";
 import * as fs from "fs";
-import { describe, it } from "mocha";
+import { describe, it, beforeEach, afterEach } from "mocha";
 import path = require("path");
+import * as sinon from "sinon";
 
 import { setExtensionStoragePath } from "../../../src/config/globals";
 import {
@@ -10,23 +11,33 @@ import {
   clearCache,
 } from "../../../src/utils/addonCache";
 
-describe("addonCache.ts", async () => {
-  describe("addToCache", async () => {
-    it("should create the cache folder, file, and add data if it does not exist", async () => {
-      const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
-      if (!fs.existsSync(workspaceFolder)) {
-        fs.mkdirSync(workspaceFolder);
-      }
-      const storagePath = path.resolve(workspaceFolder, ".test_assay");
-      if (fs.existsSync(storagePath)) {
-        fs.rmSync(storagePath, { recursive: true });
-      }
+const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
+const storagePath = path.resolve(workspaceFolder, ".test_assay");
+const cachePath = path.resolve(storagePath, ".cache");
+const filePath = path.resolve(cachePath, "test-guid.json");
 
+describe("addonCache.ts", async () => {
+  beforeEach(() => {
+    if (!fs.existsSync(workspaceFolder)) {
+      fs.mkdirSync(workspaceFolder);
+    }
+    if (!fs.existsSync(storagePath)) {
+      fs.mkdirSync(storagePath);
+    }
+  });
+
+  afterEach(async () => {
+    sinon.restore();
+    if (fs.existsSync(workspaceFolder)) {
+      await fs.promises.rm(workspaceFolder, { recursive: true });
+    }
+  });
+
+  describe("addToCache()", async () => {
+    it("should create the cache folder, file, and add data if it does not exist", async () => {
       setExtensionStoragePath(storagePath);
 
       await addToCache("test-guid", "test-key", "test-value");
-      const cachePath = path.resolve(storagePath, ".cache");
-      const filePath = path.resolve(cachePath, "test-guid.json");
 
       expect(fs.existsSync(storagePath)).to.be.true;
       expect(fs.existsSync(cachePath)).to.be.true;
@@ -34,23 +45,11 @@ describe("addonCache.ts", async () => {
 
       const data = fs.readFileSync(filePath, "utf8");
       expect(data).to.equal(`{"test-key":"test-value"}`);
-
-      fs.rmSync(storagePath, { recursive: true });
     });
 
     it("should modify the data in the cache file if it does exist", async () => {
-      const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
-      if (!fs.existsSync(workspaceFolder)) {
-        fs.mkdirSync(workspaceFolder);
-      }
-      const storagePath = path.resolve(workspaceFolder, ".test_assay");
-      if (!fs.existsSync(storagePath)) {
-        fs.mkdirSync(storagePath);
-      }
       setExtensionStoragePath(storagePath);
 
-      const cachePath = path.resolve(storagePath, ".cache");
-      const filePath = path.resolve(cachePath, "test-guid.json");
       if (!fs.existsSync(cachePath)) {
         fs.mkdirSync(cachePath);
       }
@@ -60,39 +59,16 @@ describe("addonCache.ts", async () => {
 
       const data = fs.readFileSync(filePath, "utf8");
       expect(data).to.equal(`{"test-key":"test-value-2"}`);
-
-      fs.rmSync(storagePath, { recursive: true });
     });
   });
 
-  describe("getFromCache", async () => {
+  describe("getFromCache()", async () => {
     it("should return undefined if the cache file does not exist", async () => {
-      const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
-      if (!fs.existsSync(workspaceFolder)) {
-        fs.mkdirSync(workspaceFolder);
-      }
-      const storagePath = path.resolve(workspaceFolder, ".test_assay");
-      if (fs.existsSync(storagePath)) {
-        fs.rmSync(storagePath, { recursive: true });
-      }
-
       const result = await getFromCache(storagePath, "test-guid", "test-key");
-
       expect(result).to.be.undefined;
     });
 
     it("should return the data from the cache file if it does exist", async () => {
-      const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
-      if (!fs.existsSync(workspaceFolder)) {
-        fs.mkdirSync(workspaceFolder);
-      }
-      const storagePath = path.resolve(workspaceFolder, ".test_assay");
-      if (!fs.existsSync(storagePath)) {
-        fs.mkdirSync(storagePath);
-      }
-
-      const cachePath = path.resolve(storagePath, ".cache");
-      const filePath = path.resolve(cachePath, "test-guid.json");
       if (!fs.existsSync(cachePath)) {
         fs.mkdirSync(cachePath);
       }
@@ -101,23 +77,11 @@ describe("addonCache.ts", async () => {
       const result = await getFromCache(storagePath, "test-guid", "test-key");
 
       expect(result).to.equal("test-value");
-
-      fs.rmSync(storagePath, { recursive: true });
     });
   });
 
-  describe("clearCache", async () => {
+  describe("clearCache()", async () => {
     it("should delete the cache folder and return true", async () => {
-      const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
-      if (!fs.existsSync(workspaceFolder)) {
-        fs.mkdirSync(workspaceFolder);
-      }
-      const storagePath = path.resolve(workspaceFolder, ".test_assay");
-      if (!fs.existsSync(storagePath)) {
-        fs.mkdirSync(storagePath);
-      }
-
-      const cachePath = path.resolve(storagePath, ".cache");
       if (!fs.existsSync(cachePath)) {
         fs.mkdirSync(cachePath);
       }

--- a/test/suite/utils/requestAuth.test.ts
+++ b/test/suite/utils/requestAuth.test.ts
@@ -32,7 +32,6 @@ describe("requestAuth.ts", () => {
       const getCredsStub = sinon.stub(credUtils, "getCredsFromStorage");
       getCredsStub.resolves(creds);
       const result = await makeAuthHeader();
-      // expect it to have a key called authorization
       expect(result).to.have.property("Authorization");
     });
   });

--- a/test/suite/utils/reviewRootDir.test.ts
+++ b/test/suite/utils/reviewRootDir.test.ts
@@ -14,32 +14,38 @@ describe("reviewRootDir.ts", async () => {
     sinon.restore();
   });
 
-  describe("getRootFolderPath", async () => {
+  describe("getRootFolderPath()", async () => {
     it("should return the folder that is already set", async () => {
-      const stub = sinon.stub(vscode.workspace, "getConfiguration");
-      stub.returns({
+      const getConfigurationStub = sinon.stub(
+        vscode.workspace,
+        "getConfiguration"
+      );
+      getConfigurationStub.returns({
         get: () => {
           return "/test";
         },
       } as any);
 
-      const stub2 = sinon.stub(fs, "existsSync");
-      stub2.returns(true);
+      const existsSyncStub = sinon.stub(fs, "existsSync");
+      existsSyncStub.returns(true);
 
       const result = await getRootFolderPath();
       expect(result).to.equal("/test");
     });
 
     it("should throw an error if the folder is not set", async () => {
-      const stub = sinon.stub(vscode.workspace, "getConfiguration");
-      stub.returns({
+      const getConfigurationStub = sinon.stub(
+        vscode.workspace,
+        "getConfiguration"
+      );
+      getConfigurationStub.returns({
         get: () => {
           return undefined;
         },
       } as any);
 
-      const stub2 = sinon.stub(vscode.window, "showOpenDialog");
-      stub2.resolves(undefined);
+      const showOpenDialogStub = sinon.stub(vscode.window, "showOpenDialog");
+      showOpenDialogStub.resolves(undefined);
 
       try {
         await getRootFolderPath();
@@ -50,8 +56,11 @@ describe("reviewRootDir.ts", async () => {
     });
 
     it("should return the new folder if the old one doesn't exist", async () => {
-      const stub = sinon.stub(vscode.workspace, "getConfiguration");
-      stub.returns({
+      const getConfigurationStub = sinon.stub(
+        vscode.workspace,
+        "getConfiguration"
+      );
+      getConfigurationStub.returns({
         get: () => {
           return undefined;
         },
@@ -60,30 +69,28 @@ describe("reviewRootDir.ts", async () => {
         },
       } as any);
 
-      const stub2 = sinon.stub(vscode.window, "showOpenDialog");
+      const showOpenDialogStub = sinon.stub(vscode.window, "showOpenDialog");
       const uri = vscode.Uri.file("test");
-      stub2.resolves([uri]);
+      showOpenDialogStub.resolves([uri]);
 
       const result = await getRootFolderPath();
       expect(result).to.equal("/test");
     });
   });
 
-  describe("selectRootFolder", async () => {
+  describe("selectRootFolder()", async () => {
     it("should return undefined if no folder is chosen", async () => {
-      // stub showOpenDialog to return undefined
-      const stub = sinon.stub(vscode.window, "showOpenDialog");
-      stub.resolves(undefined);
+      const showOpenDialogStub = sinon.stub(vscode.window, "showOpenDialog");
+      showOpenDialogStub.resolves(undefined);
 
       const result = await selectRootFolder();
       expect(result).to.be.undefined;
     });
 
     it("should return the chosen folder", async () => {
-      // stub showOpenDialog to return a folder
-      const stub = sinon.stub(vscode.window, "showOpenDialog");
+      const showOpenDialogStub = sinon.stub(vscode.window, "showOpenDialog");
       const uri = vscode.Uri.file("test");
-      stub.resolves([uri]);
+      showOpenDialogStub.resolves([uri]);
 
       const result = await selectRootFolder();
       expect(result).to.equal("/test");

--- a/test/suite/views/sidebarView.test.ts
+++ b/test/suite/views/sidebarView.test.ts
@@ -6,9 +6,9 @@ import {
   AssayTreeItem,
 } from "../../../src/views/sidebarView";
 
-describe("sidebarView.ts", () => {
-  const sidebarView = new AssayTreeDataProvider();
+const sidebarView = new AssayTreeDataProvider();
 
+describe("sidebarView.ts", () => {
   it("should get the children", async () => {
     const children = await sidebarView.getChildren();
     const tab = children[0];


### PR DESCRIPTION
I've given all stubs proper names, took out constants and functions for readability, utilized beforeEach and afterEach for setup and cleanup instead of doing it in each test. the addonVersions tests are a little messy due to the fetch stubs, but trying to make a common variable between them didn't help much with line efficiency. I removed the individual tests for the errors since they can all be done with one test of the actual error function. Anything else for the tests that I should change? 

Also, I was missing return statements for the error functions, just added that back in.