### PR TITLE
Third party diff tool launching

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -1,7 +1,7 @@
 {
   "all": true,
   "include": ["out/src/**"],
-  "exclude": ["**/node_modules/**", "**/test/**", "out/src/types.js", "out/src/views/welcomeView.js", "**/config/**"],
+  "exclude": ["**/node_modules/**", "**/test/**", "out/src/commands/launchDiff.js", "out/src/types.js", "out/src/views/welcomeView.js", "**/config/**"],
   "reporter": ["lcov", "text"],
   "lines": 5
 }

--- a/.c8rc
+++ b/.c8rc
@@ -1,7 +1,7 @@
 {
   "all": true,
   "include": ["out/src/**"],
-  "exclude": ["**/node_modules/**", "**/test/**", "out/src/commands/launchDiff.js", "out/src/types.js", "out/src/views/welcomeView.js", "**/config/**"],
+  "exclude": ["**/node_modules/**", "**/test/**", "out/src/types.js", "out/src/views/welcomeView.js", "**/config/**"],
   "reporter": ["lcov", "text"],
   "lines": 5
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,21 @@
         "assay.rootFolder": {
           "type": "string",
           "default": ""
+        },
+        "assay.diffTool": {
+          "type": "string",
+          "default": ""
         }
       }
+    },
+    "menus": {
+      "explorer/context": [
+        {
+          "when": "explorerResourceIsFolder && listDoubleSelection",
+          "command": "assay.openInDiffTool",
+          "group": "navigation"
+        }
+      ]
     },
     "views": {
       "explorer": [
@@ -33,6 +46,10 @@
       {
         "command": "assay.welcome",
         "title": "Assay Introduction"
+      },
+      {
+        "command": "assay.openInDiffTool",
+        "title": "(Assay) Open in Diff Tool"
       }
     ]
   },

--- a/src/commands/launchDiff.ts
+++ b/src/commands/launchDiff.ts
@@ -10,6 +10,9 @@ export async function openInDiffTool(uris: [vscode.Uri, vscode.Uri]) {
   const rightPath = rightUri.fsPath;
 
   const diffCommand = await getDiffCommand();
+  if (!diffCommand) {
+    return;
+  }
 
   const terminal = vscode.window.createTerminal("External Diff Tool");
   terminal.sendText(`${diffCommand} ${leftPath} ${rightPath}`);

--- a/src/commands/launchDiff.ts
+++ b/src/commands/launchDiff.ts
@@ -1,3 +1,4 @@
+import { spawn } from "child_process";
 import * as vscode from "vscode";
 
 import { getDiffCommand } from "../utils/diffTool";
@@ -14,7 +15,12 @@ export async function openInDiffTool(uris: [vscode.Uri, vscode.Uri]) {
     return;
   }
 
-  const terminal = vscode.window.createTerminal("External Diff Tool");
-  terminal.sendText(`${diffCommand} ${leftPath} ${rightPath}`);
-  terminal.show();
+  const diffProcess = spawn(diffCommand, [leftPath, rightPath]);
+  diffProcess.on("error", (err) => {
+    vscode.window.showErrorMessage(
+      `External Diff Tool failed to launch: ${err.message}`
+    );
+    return;
+  });
+  return true;
 }

--- a/src/commands/launchDiff.ts
+++ b/src/commands/launchDiff.ts
@@ -1,0 +1,17 @@
+import * as vscode from "vscode";
+
+import { getDiffCommand } from "../utils/diffTool";
+
+export async function openInDiffTool(uris: [vscode.Uri, vscode.Uri]) {
+  const [left, right] = uris;
+  const leftUri = vscode.Uri.parse(left.toString());
+  const rightUri = vscode.Uri.parse(right.toString());
+  const leftPath = leftUri.fsPath;
+  const rightPath = rightUri.fsPath;
+
+  const diffCommand = await getDiffCommand();
+
+  const terminal = vscode.window.createTerminal("External Diff Tool");
+  terminal.sendText(`${diffCommand} ${leftPath} ${rightPath}`);
+  terminal.show();
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { Uri } from "vscode";
 
 import { downloadAndExtract } from "./commands/getAddon";
 import { getApiKeyFromUser, getSecretFromUser } from "./commands/getApiCreds";
@@ -34,6 +35,40 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.commands.registerCommand("assay.getSecret", () => {
     getSecretFromUser();
   });
+
+  vscode.commands.registerCommand(
+    "assay.openInDiffTool",
+    async (_e: Uri, uris?: [Uri, Uri]) => {
+      if (!uris) {
+        return;
+      }
+      const [left, right] = uris;
+      const leftUri = vscode.Uri.parse(left.toString());
+      const rightUri = vscode.Uri.parse(right.toString());
+      const leftPath = leftUri.fsPath;
+      const rightPath = rightUri.fsPath;
+
+      const config = vscode.workspace.getConfiguration("assay");
+      let diffCommand = config.get<string>("diffTool");
+
+
+      if (!diffCommand) {
+        const input = await vscode.window.showInputBox({
+          prompt: "Please enter your diff tool command (e.g. diff -rq).",
+        });
+        if (!input) {
+          return;
+        }
+        await config.update("diffTool", input, true);
+        diffCommand = input;
+      }
+
+
+      const terminal = vscode.window.createTerminal("External Diff Tool");
+      terminal.sendText(`${diffCommand} ${leftPath} ${rightPath}`);
+      terminal.show();
+    }
+  );
 
   const sidebar = vscode.window.createTreeView("assayCommands", {
     treeDataProvider: new AssayTreeDataProvider(),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { Uri } from "vscode";
 
 import { downloadAndExtract } from "./commands/getAddon";
 import { getApiKeyFromUser, getSecretFromUser } from "./commands/getApiCreds";
+import { openInDiffTool } from "./commands/launchDiff";
 import { updateTaskbar } from "./commands/updateTaskbar";
 import {
   setExtensionSecretStorage,
@@ -42,29 +43,7 @@ export async function activate(context: vscode.ExtensionContext) {
       if (!uris) {
         return;
       }
-      const [left, right] = uris;
-      const leftUri = vscode.Uri.parse(left.toString());
-      const rightUri = vscode.Uri.parse(right.toString());
-      const leftPath = leftUri.fsPath;
-      const rightPath = rightUri.fsPath;
-
-      const config = vscode.workspace.getConfiguration("assay");
-      let diffCommand = config.get<string>("diffTool");
-
-      if (!diffCommand) {
-        const input = await vscode.window.showInputBox({
-          prompt: "Please enter your diff tool command (e.g. diff -rq).",
-        });
-        if (!input) {
-          return;
-        }
-        await config.update("diffTool", input, true);
-        diffCommand = input;
-      }
-
-      const terminal = vscode.window.createTerminal("External Diff Tool");
-      terminal.sendText(`${diffCommand} ${leftPath} ${rightPath}`);
-      terminal.show();
+      await openInDiffTool(uris);
     }
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,7 +51,6 @@ export async function activate(context: vscode.ExtensionContext) {
       const config = vscode.workspace.getConfiguration("assay");
       let diffCommand = config.get<string>("diffTool");
 
-
       if (!diffCommand) {
         const input = await vscode.window.showInputBox({
           prompt: "Please enter your diff tool command (e.g. diff -rq).",
@@ -62,7 +61,6 @@ export async function activate(context: vscode.ExtensionContext) {
         await config.update("diffTool", input, true);
         diffCommand = input;
       }
-
 
       const terminal = vscode.window.createTerminal("External Diff Tool");
       terminal.sendText(`${diffCommand} ${leftPath} ${rightPath}`);

--- a/src/utils/addonExtract.ts
+++ b/src/utils/addonExtract.ts
@@ -55,7 +55,7 @@ export async function extractAddon(
   vscode.window.showInformationMessage("Extraction complete");
 
   // make files read-only
-  (await fs.promises.readdir(addonVersionFolderPath)).forEach((file) => {
-    fs.chmodSync(`${addonVersionFolderPath}/${file}`, 0o444);
-  });
+  // (await fs.promises.readdir(addonVersionFolderPath)).forEach((file) => {
+  //   fs.chmodSync(`${addonVersionFolderPath}/${file}`, 0o444);
+  // });
 }

--- a/src/utils/diffTool.ts
+++ b/src/utils/diffTool.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 
 export async function setDiffCommand(config: vscode.WorkspaceConfiguration) {
   const input = await vscode.window.showInputBox({
-    prompt: "Please enter your diff tool command (e.g. diff -rq).",
+    prompt: "Please enter your diff tool command (e.g. bcomp @script.bc).",
   });
   if (!input) {
     return;

--- a/src/utils/diffTool.ts
+++ b/src/utils/diffTool.ts
@@ -1,0 +1,19 @@
+import * as vscode from "vscode";
+
+export async function setDiffCommand(config: vscode.WorkspaceConfiguration) {
+  const input = await vscode.window.showInputBox({
+    prompt: "Please enter your diff tool command (e.g. diff -rq).",
+  });
+  if (!input) {
+    return;
+  }
+  await config.update("diffTool", input, true);
+  return input;
+}
+
+export async function getDiffCommand() {
+  const config = vscode.workspace.getConfiguration("assay");
+  const diffCommand =
+    config.get<string>("diffTool") || (await setDiffCommand(config));
+  return diffCommand;
+}

--- a/test/suite/commands/launchDiff.test.ts
+++ b/test/suite/commands/launchDiff.test.ts
@@ -1,0 +1,67 @@
+import { expect } from "chai";
+import { describe, it, afterEach } from "mocha";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+
+import { openInDiffTool } from "../../../src/commands/launchDiff";
+import * as diffTool from "../../../src/utils/diffTool";
+import exp = require("constants");
+
+describe("launchDiff.ts", async () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("openInDiffTool()", () => {
+    it("should return undefined if no diff command is provided", async () => {
+      const getDiffCommandStub = sinon.stub(diffTool, "getDiffCommand");
+      getDiffCommandStub.resolves(undefined);
+
+      const result = await openInDiffTool([
+        vscode.Uri.parse("file:///path/to/file1"),
+        vscode.Uri.parse("file:///path/to/file2"),
+      ]);
+      expect(result).to.be.undefined;
+    });
+
+    it("should launch a terminal with the diff command and file paths", async () => {
+      const getDiffCommandStub = sinon.stub(diffTool, "getDiffCommand");
+      getDiffCommandStub.resolves("diff -rq");
+
+      // make and stub an entire fake terminal.
+      const terminalStub = sinon.stub(vscode.window, "createTerminal");
+      const fakeCreationOptions: vscode.TerminalOptions = {};
+      const fakeTerminalState: vscode.TerminalState = {
+        isInteractedWith: false,
+      };
+      const sendTextStub = sinon.stub();
+      terminalStub.returns({
+        sendText: sendTextStub,
+        show: sinon.stub(),
+        name: "",
+        processId: Promise.resolve(0),
+        creationOptions: fakeCreationOptions,
+        exitStatus: undefined,
+        state: fakeTerminalState,
+        hide: function (): void {
+          throw new Error("Function not implemented.");
+        },
+        dispose: function (): void {
+          throw new Error("Function not implemented.");
+        },
+      });
+
+      await openInDiffTool([
+        vscode.Uri.parse("file:///path/to/file1"),
+        vscode.Uri.parse("file:///path/to/file2"),
+      ]);
+
+      expect(terminalStub.calledOnce).to.be.true;
+      expect(terminalStub.firstCall.args[0]).to.include("External Diff Tool");
+      expect(sendTextStub.calledOnce).to.be.true;
+      expect(sendTextStub.firstCall.args[0]).to.equal(
+        "diff -rq /path/to/file1 /path/to/file2"
+      );
+    });
+  });
+});

--- a/test/suite/utils/AddonExtract.test.ts
+++ b/test/suite/utils/AddonExtract.test.ts
@@ -56,7 +56,7 @@ describe("AddonExtract.ts", async () => {
       const fileStats = fs.statSync(
         path.resolve(extractedVersionFolder, "test.txt")
       );
-      expect(fileStats.mode).to.equal(0o100444);
+      // expect(fileStats.mode).to.equal(0o100444);
     });
 
     it("should overwrite an existing addon", async () => {
@@ -87,7 +87,7 @@ describe("AddonExtract.ts", async () => {
       const fileStats = fs.statSync(
         path.resolve(extractedVersionFolder, "test.txt")
       );
-      expect(fileStats.mode).to.equal(0o100444);
+      // expect(fileStats.mode).to.equal(0o100444);
 
       const fileContent = fs.readFileSync(
         path.resolve(extractedVersionFolder, "test.txt"),

--- a/test/suite/utils/diffTool.test.ts
+++ b/test/suite/utils/diffTool.test.ts
@@ -1,0 +1,61 @@
+import { expect } from "chai";
+import { describe, it, afterEach } from "mocha";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+
+import { setDiffCommand, getDiffCommand } from "../../../src/utils/diffTool";
+
+describe("diffTool.ts", async () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("setDiffCommand()", () => {
+    it("should return undefined if no input is provided", async () => {
+      const config = vscode.workspace.getConfiguration("assay");
+      const inputBoxStub = sinon.stub(vscode.window, "showInputBox");
+      inputBoxStub.resolves(undefined);
+      const result = await setDiffCommand(config);
+      expect(result).to.be.undefined;
+    });
+
+    it("should return the input and update the config if input is provided", async () => {
+      const configStub = sinon.stub(vscode.workspace, "getConfiguration");
+      const config = {
+        update: sinon.stub(),
+        get: sinon.stub(),
+        has: sinon.stub(),
+        let: sinon.stub(),
+        inspect: sinon.stub(),
+      };
+      configStub.resolves(config);
+
+      const inputBoxStub = sinon.stub(vscode.window, "showInputBox");
+      inputBoxStub.resolves("diff -rq");
+
+      const result = await setDiffCommand(config);
+
+      expect(result).to.equal("diff -rq");
+      expect(config.update.calledOnce).to.be.true;
+    });
+  });
+
+  describe("getDiffCommand()", () => {
+    it("should return the diff command from the config if it exists", async () => {
+      const configStub = sinon.stub(vscode.workspace, "getConfiguration");
+      const config = {
+        update: sinon.stub(),
+        get: sinon.stub(),
+        has: sinon.stub(),
+        let: sinon.stub(),
+        inspect: sinon.stub(),
+      };
+      configStub.returns(config);
+      config.get.returns("diff -rq");
+
+      const result = await getDiffCommand();
+      expect(result).to.equal("diff -rq");
+      expect(config.get.calledOnce).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
The user can input their own command that will automatically have the arguments of the filepaths filled for their own diff tool. It also shows the "Open in diff tool" in the right click menu ONLY if there are exactly two folders selected.

Temporarily removed read-only feature as that causes issues with some tools.