### PR TITLE
Add colourful tree indicators for comments in files

### DIFF
--- a/src/commands/loadComments.ts
+++ b/src/commands/loadComments.ts
@@ -1,6 +1,7 @@
 import path = require("path");
 import * as vscode from "vscode";
 
+import { getFileDecorator } from "../config/globals";
 import { getFromCache } from "../utils/addonCache";
 import { getRootFolderPath } from "../utils/reviewRootDir";
 
@@ -45,4 +46,9 @@ export async function loadFileComments() {
     }
   }
   editor.setDecorations(commentDecoration, decorations);
+
+  console.log("setting file decoration");
+  // set the decoration in the filetree
+  const fileDecorator = getFileDecorator();
+  fileDecorator.updateDecorations(doc.uri);
 }

--- a/src/commands/loadComments.ts
+++ b/src/commands/loadComments.ts
@@ -30,6 +30,8 @@ export async function loadFileComments() {
   const version = relativePath.split("/")[2];
   const filepath = relativePath.split(version)[1];
 
+  const fileDecorator = getFileDecorator();
+  fileDecorator.updateDecorations(doc.uri);
   const comments = await getFromCache(guid, [version, filepath]);
   if (!comments) {
     return;
@@ -46,9 +48,4 @@ export async function loadFileComments() {
     }
   }
   editor.setDecorations(commentDecoration, decorations);
-
-  console.log("setting file decoration");
-  // set the decoration in the filetree
-  const fileDecorator = getFileDecorator();
-  fileDecorator.updateDecorations(doc.uri);
 }

--- a/src/commands/loadComments.ts
+++ b/src/commands/loadComments.ts
@@ -27,13 +27,14 @@ export async function loadFileComments() {
 
   const relativePath = fullPath.replace(rootFolder, "");
   const guid = relativePath.split("/")[1];
-  const version = relativePath.split("/")[2];
-  const filepath = relativePath.split(version)[1];
+  const keys = relativePath.split("/").slice(2);
 
   const fileDecorator = getFileDecorator();
   fileDecorator.updateDecorations(doc.uri);
-  const comments = await getFromCache(guid, [version, filepath]);
+
+  const comments = await getFromCache(guid, keys);
   if (!comments) {
+    editor.setDecorations(commentDecoration, []);
     return;
   }
 

--- a/src/commands/makeComment.ts
+++ b/src/commands/makeComment.ts
@@ -23,7 +23,12 @@ export async function makePanel(
 
   panel.webview.onDidReceiveMessage(async (message) => {
     panel.dispose();
-    await addToCache(guid, [version, filepath, lineNumber], message.comment);
+    const pathParts = filepath.split("/").slice(1);
+    await addToCache(
+      guid,
+      [version, ...pathParts, lineNumber],
+      message.comment
+    );
     await loadFileComments();
   });
 
@@ -49,12 +54,9 @@ export async function makeComment() {
   const guid = relativePath.split("/")[1];
   const version = relativePath.split("/")[2];
   const filepath = relativePath.split(version)[1];
+  const keys = relativePath.split("/").slice(2);
 
-  const existingComment = await getFromCache(guid, [
-    version,
-    filepath,
-    lineNumber,
-  ]);
+  const existingComment = await getFromCache(guid, [...keys, lineNumber]);
 
   await makePanel(guid, version, filepath, lineNumber, existingComment);
 }

--- a/src/config/globals.ts
+++ b/src/config/globals.ts
@@ -1,7 +1,10 @@
 import { SecretStorage } from "vscode";
 
+import { CustomFileDecorationProvider } from "../views/fileDecorations";
+
 let secrets: SecretStorage;
 let storagePath: string;
+let fileDecorator: CustomFileDecorationProvider;
 
 export function setExtensionSecretStorage(secretStorage: SecretStorage) {
   secrets = secretStorage;
@@ -17,4 +20,12 @@ export function setExtensionStoragePath(path: string) {
 
 export function getExtensionStoragePath() {
   return storagePath;
+}
+
+export function setFileDecorator(decorator: CustomFileDecorationProvider) {
+  fileDecorator = decorator;
+}
+
+export function getFileDecorator() {
+  return fileDecorator;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,9 @@ export async function activate(context: vscode.ExtensionContext) {
   setExtensionStoragePath(storagePath);
   setExtensionSecretStorage(context.secrets);
 
+  // load comments on startup/reload
+  await loadFileComments();
+
   const reviewDisposable = vscode.commands.registerCommand(
     "assay.review",
     async function (url: string) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,12 +14,16 @@ import { updateTaskbar } from "./commands/updateTaskbar";
 import {
   setExtensionSecretStorage,
   setExtensionStoragePath,
+  setFileDecorator,
 } from "./config/globals";
+import { CustomFileDecorationProvider } from "./views/fileDecorations";
 import { AssayTreeDataProvider } from "./views/sidebarView";
 import { WelcomeView } from "./views/welcomeView";
 
 export async function activate(context: vscode.ExtensionContext) {
   const storagePath: string = context.globalStorageUri.fsPath;
+  const fileDecorator = new CustomFileDecorationProvider();
+  setFileDecorator(fileDecorator);
   setExtensionStoragePath(storagePath);
   setExtensionSecretStorage(context.secrets);
 
@@ -106,7 +110,8 @@ export async function activate(context: vscode.ExtensionContext) {
       async () => await loadFileComments()
     ),
     exportCommentsFileDisposable,
-    exportCommentsFolderDisposable
+    exportCommentsFolderDisposable,
+    vscode.window.registerFileDecorationProvider(fileDecorator)
   );
 }
 

--- a/src/utils/addonCache.ts
+++ b/src/utils/addonCache.ts
@@ -54,7 +54,6 @@ export async function addToCache(
 
   removeEmptyObjectsFromCache(levelObjects);
 
-  console.log("cacheFileJSON", cacheFileJSON);
   await fs.promises.writeFile(
     cacheFilePath,
     JSON.stringify(cacheFileJSON, null, 2)

--- a/src/utils/addonCache.ts
+++ b/src/utils/addonCache.ts
@@ -15,7 +15,7 @@ import { getExtensionStoragePath } from "../config/globals";
 export async function addToCache(
   addonGUID: string,
   keys: string[],
-  value: string
+  value: string | undefined
 ) {
   const storagePath = getExtensionStoragePath();
 
@@ -44,7 +44,12 @@ export async function addToCache(
     currentLevel = currentLevel[key] = currentLevel[key] || {};
   }
 
-  currentLevel[keys[keys.length - 1]] = value;
+  // if value is undefined, delete the key
+  if (!value) {
+    delete currentLevel[keys[keys.length - 1]];
+  } else {
+    currentLevel[keys[keys.length - 1]] = value;
+  }
 
   await fs.promises.writeFile(
     cacheFilePath,

--- a/src/views/fileDecorations.ts
+++ b/src/views/fileDecorations.ts
@@ -32,6 +32,11 @@ export async function folderHasComment(uri: vscode.Uri) {
   const guid = splitPath[1];
   const keys = splitPath.slice(2);
 
+  // if there no keys, then we are at the guid path. return false
+  if (keys.length === 0) {
+    return false;
+  }
+
   const comments = await getFromCache(guid, keys);
   // check if comments map is empty or not defined
   if (!comments || Object.keys(comments).length === 0) {

--- a/src/views/fileDecorations.ts
+++ b/src/views/fileDecorations.ts
@@ -5,17 +5,34 @@ import { Event } from "vscode";
 import { getFromCache } from "../utils/addonCache";
 import { getRootFolderPath } from "../utils/reviewRootDir";
 
-async function hasComment(uri: vscode.Uri) {
+export async function fileHasComment(uri: vscode.Uri) {
   const fullpath = uri.fsPath;
   const rootFolder = await getRootFolderPath();
 
   const filepath = fullpath.replace(rootFolder, "");
-  const guid = filepath.split("/")[1];
-  const version = filepath.split("/")[2];
-  const file = filepath.split(version)[1];
+  const splitPath = filepath.split("/");
+  const guid = splitPath[1];
+  const keys = splitPath.slice(2);
 
-  const comments = await getFromCache(guid, [version, file]);
-  console.log("comments", comments);
+  const comments = await getFromCache(guid, keys);
+  // check if comments map is empty or not defined
+  if (!comments || Object.keys(comments).length === 0) {
+    console.log("returning false");
+    return false;
+  }
+  return true;
+}
+
+export async function folderHasComment(uri: vscode.Uri) {
+  const fullpath = uri.fsPath;
+  const rootFolder = await getRootFolderPath();
+
+  const filepath = fullpath.replace(rootFolder, "");
+  const splitPath = filepath.split("/");
+  const guid = splitPath[1];
+  const keys = splitPath.slice(2);
+
+  const comments = await getFromCache(guid, keys);
   // check if comments map is empty or not defined
   if (!comments || Object.keys(comments).length === 0) {
     return false;
@@ -29,20 +46,23 @@ export class CustomFileDecorationProvider {
   > = new vscode.EventEmitter<vscode.Uri | vscode.Uri[]>();
   readonly onDidChangeFileDecorations: Event<vscode.Uri | vscode.Uri[]> =
     this._onDidChangeFileDecorations.event;
-  private _folderCommentPaths: Set<string> = new Set();
 
   async provideFileDecoration(uri: vscode.Uri) {
     // if its a file and has a comment, return the decoration
     // Also if it's a folder of a file that has a comment, return the decoration
-    if (this._folderCommentPaths.has(uri.fsPath) || (await hasComment(uri))) {
-      // update the decoration of the parent folder
-      const parentFolder = uri.with({
-        path: uri.path.split("/").slice(0, -1).join("/"),
-      });
-      if (parentFolder.fsPath !== (await getRootFolderPath())) {
-        this.updateDecorations(parentFolder);
-      }
 
+    // go up the parent folders until the root too
+    const parentFolder = uri.with({
+      path: uri.path.split("/").slice(0, -1).join("/"),
+    });
+    if (parentFolder.fsPath !== (await getRootFolderPath())) {
+      this.updateDecorations(parentFolder);
+    }
+
+    if (
+      (fs.lstatSync(uri.fsPath).isFile() && (await fileHasComment(uri))) ||
+      (fs.lstatSync(uri.fsPath).isDirectory() && (await folderHasComment(uri)))
+    ) {
       return {
         badge: "C",
         color: new vscode.ThemeColor("charts.green"),
@@ -51,10 +71,6 @@ export class CustomFileDecorationProvider {
   }
 
   updateDecorations(uri: vscode.Uri) {
-    // check if uri is a folder using fs.stat
-    if (fs.lstatSync(uri.fsPath).isDirectory()) {
-      this._folderCommentPaths.add(uri.fsPath);
-    }
     this._onDidChangeFileDecorations.fire(uri);
   }
 }

--- a/src/views/fileDecorations.ts
+++ b/src/views/fileDecorations.ts
@@ -1,0 +1,56 @@
+import * as vscode from "vscode";
+import { Event } from "vscode";
+
+import { getFromCache } from "../utils/addonCache";
+import { getRootFolderPath } from "../utils/reviewRootDir";
+
+async function hasComment(uri: vscode.Uri) {
+  if (uri.scheme !== "file") {
+    return false;
+  }
+  const fullpath = uri.fsPath;
+  const rootFolder = await getRootFolderPath();
+
+  const filepath = fullpath.replace(rootFolder, "");
+  const guid = filepath.split("/")[1];
+  const version = filepath.split("/")[2];
+  const file = filepath.split(version)[1];
+
+  const comments = await getFromCache(guid, [version, file]);
+  if (comments) {
+    return true;
+  }
+}
+
+export class CustomFileDecorationProvider {
+  private _onDidChangeFileDecorations: vscode.EventEmitter<
+    vscode.Uri | vscode.Uri[]
+  > = new vscode.EventEmitter<vscode.Uri | vscode.Uri[]>();
+  readonly onDidChangeFileDecorations: Event<vscode.Uri | vscode.Uri[]> =
+    this._onDidChangeFileDecorations.event;
+  private _folderCommentPaths: Set<string> = new Set();
+
+  async provideFileDecoration(uri: vscode.Uri) {
+    // if its a file and has a comment, return the decoration
+    // Also if it's a folder of a file that has a comment, return the decoration
+    if ((await hasComment(uri)) || this._folderCommentPaths.has(uri.fsPath)) {
+      // update the decoration of the parent folder
+      const parentFolder = uri.with({
+        path: uri.path.split("/").slice(0, -1).join("/"),
+      });
+      if (parentFolder.fsPath !== (await getRootFolderPath())) {
+        this.updateDecorations(parentFolder);
+      }
+
+      return {
+        badge: "C",
+        color: new vscode.ThemeColor("charts.green"),
+      };
+    }
+  }
+
+  updateDecorations(uri: vscode.Uri) {
+    this._folderCommentPaths.add(uri.fsPath); // maybe a better way to do this?
+    this._onDidChangeFileDecorations.fire(uri);
+  }
+}

--- a/src/views/fileDecorations.ts
+++ b/src/views/fileDecorations.ts
@@ -17,7 +17,6 @@ export async function fileHasComment(uri: vscode.Uri) {
   const comments = await getFromCache(guid, keys);
   // check if comments map is empty or not defined
   if (!comments || Object.keys(comments).length === 0) {
-    console.log("returning false");
     return false;
   }
   return true;
@@ -69,7 +68,7 @@ export class CustomFileDecorationProvider {
       (fs.lstatSync(uri.fsPath).isDirectory() && (await folderHasComment(uri)))
     ) {
       return {
-        badge: "C",
+        badge: "✎",
         color: new vscode.ThemeColor("charts.green"),
       };
     }

--- a/test/suite/commands/loadComments.test.ts
+++ b/test/suite/commands/loadComments.test.ts
@@ -1,13 +1,24 @@
 import { expect } from "chai";
-import { describe, it, afterEach } from "mocha";
+import { describe, it, afterEach, beforeEach } from "mocha";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 
 import { loadFileComments } from "../../../src/commands/loadComments";
+import * as constants from "../../../src/config/globals";
 import * as cacheFunctions from "../../../src/utils/addonCache";
 import * as reviewRootDir from "../../../src/utils/reviewRootDir";
 
 describe("loadComments.ts", async () => {
+  beforeEach(() => {
+    const getFileDecoratorStub = sinon.stub(
+      constants,
+      "getFileDecorator"
+    );
+    getFileDecoratorStub.returns({
+      updateDecorations: sinon.stub(),
+    } as any);
+  });
+
   afterEach(async () => {
     sinon.restore();
   });
@@ -56,6 +67,7 @@ describe("loadComments.ts", async () => {
               "test-root-folder-path/test-guid/test-version/test-filepath",
           },
         },
+        setDecorations: sinon.stub(),
       });
 
       const getRootFolderPathStub = sinon.stub(

--- a/test/suite/commands/makeComment.test.ts
+++ b/test/suite/commands/makeComment.test.ts
@@ -69,7 +69,7 @@ describe("makeComment.ts", async () => {
       expect(getFromCacheStub.args[0][0]).to.equal("test-guid");
       expect(getFromCacheStub.args[0][1]).to.deep.equal([
         "test-version",
-        "/test-filepath",
+        "test-filepath",
         "test-lineNumber",
       ]);
     });

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -16,7 +16,7 @@ describe("extension.ts", () => {
     expect(commands).to.include.members(["assay.get"]);
     expect(commands).to.include.members(["assay.welcome"]);
     expect(commands).to.include.members(["assay.review"]);
-    expect(context.subscriptions.length).to.equal(12);
+    expect(context.subscriptions.length).to.equal(13);
   });
 
   it("should deactivate and return undefined", async () => {

--- a/test/suite/utils/addonCache.test.ts
+++ b/test/suite/utils/addonCache.test.ts
@@ -92,4 +92,19 @@ describe("addonCache.ts", async () => {
       expect(fs.existsSync(cachePath)).to.be.false;
     });
   });
+
+  describe("removeEmptyObjectsFromCache()", async () => {
+    it("should remove empty objects from the cache", async () => {
+      // all of this should be deleted since there is no actual data, just keys
+      await addToCache("test-guid", ["test-key", "test-key-2", "test-key-3"], "");
+
+      expect(fs.existsSync(filePath)).to.be.true;
+
+      const json = fs.readFileSync(filePath, "utf8");
+      const data = JSON.parse(json);
+      expect(data).to.deep.equal({});
+    });
+
+    
+  });
 });

--- a/test/suite/views/fileDecorations.test.ts
+++ b/test/suite/views/fileDecorations.test.ts
@@ -3,8 +3,8 @@ import { describe, it, afterEach, beforeEach } from "mocha";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 
-import * as reviewRootDir from "../../../src/utils/reviewRootDir";
 import * as addonCache from "../../../src/utils/addonCache";
+import * as reviewRootDir from "../../../src/utils/reviewRootDir";
 import {
   fileHasComment,
   folderHasComment,

--- a/test/suite/views/fileDecorations.test.ts
+++ b/test/suite/views/fileDecorations.test.ts
@@ -100,5 +100,14 @@ describe("fileDecorations.ts", async () => {
             ])
             ).to.be.true;
         });
+
+        it("should return false if the folder is the guid folder", async () => {
+            const result = await folderHasComment(
+                vscode.Uri.file(
+                    "test-root-folder-path/test-guid"
+                )
+            );
+            expect(result).to.be.false;
+        });
     });
 });

--- a/test/suite/views/fileDecorations.test.ts
+++ b/test/suite/views/fileDecorations.test.ts
@@ -1,0 +1,104 @@
+import { expect } from "chai";
+import { describe, it, afterEach, beforeEach } from "mocha";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+
+import * as reviewRootDir from "../../../src/utils/reviewRootDir";
+import * as addonCache from "../../../src/utils/addonCache";
+import {
+  fileHasComment,
+  folderHasComment,
+  CustomFileDecorationProvider,
+} from "../../../src/views/fileDecorations";
+
+describe("fileDecorations.ts", async () => {
+  beforeEach(() => {
+    const getRootFolderPathStub = sinon.stub(
+      reviewRootDir,
+      "getRootFolderPath"
+    );
+    getRootFolderPathStub.resolves("test-root-folder-path/");
+  });
+
+  afterEach(async () => {
+    sinon.restore();
+  });
+
+  describe("fileHasComment()", async () => {
+    it("should return false if there are no comments", async () => {
+      const getFromCacheStub = sinon.stub(addonCache, "getFromCache");
+      getFromCacheStub.resolves(undefined);
+
+      const result = await fileHasComment(
+        vscode.Uri.file(
+          "test-root-folder-path/test-guid/test-version/test-filepath"
+        )
+      );
+      expect(result).to.be.false;
+      expect(
+        getFromCacheStub.calledWith("test-guid", [
+          "test-version",
+          "test-filepath",
+        ])
+      ).to.be.true;
+    });
+
+    it("should return true if there are comments", async () => {
+        const getFromCacheStub = sinon.stub(addonCache, "getFromCache");
+        getFromCacheStub.resolves({ "test-key": "test-value" });
+
+        const result = await fileHasComment(
+          vscode.Uri.file(
+            "test-root-folder-path/test-guid/test-version/test-filepath"
+          )
+        );
+
+        expect(result).to.be.true;
+        expect(
+          getFromCacheStub.calledWith("test-guid", [
+            "test-version",
+            "test-filepath",
+          ])
+        ).to.be.true;
+    });
+  });
+
+    describe("folderHasComment()", async () => {
+        it("should return false if there are no comments", async () => {
+            const getFromCacheStub = sinon.stub(addonCache, "getFromCache");
+            getFromCacheStub.resolves(undefined);
+    
+            const result = await folderHasComment(
+            vscode.Uri.file(
+                "test-root-folder-path/test-guid/test-version/test-folderpath"
+            )
+            );
+            expect(result).to.be.false;
+            expect(
+            getFromCacheStub.calledWith("test-guid", [
+                "test-version",
+                "test-folderpath",
+            ])
+            ).to.be.true;
+        });
+    
+        it("should return true if there are comments", async () => {
+            const getFromCacheStub = sinon.stub(addonCache, "getFromCache");
+            getFromCacheStub.resolves({ "test-key": "test-value" });
+    
+            const result = await folderHasComment(
+            vscode.Uri.file(
+                "test-root-folder-path/test-guid/test-version/test-folderpath"
+            )
+            );
+    
+            expect(result).to.be.true;
+            expect(
+            getFromCacheStub.calledWith("test-guid", [
+                "test-version",
+                "test-folderpath",
+            ])
+            ).to.be.true;
+        });
+    });
+});


### PR DESCRIPTION
<img width="207" alt="Screenshot 2023-10-23 at 1 48 56 AM" src="https://github.com/mozilla/assay/assets/63402349/03e163f3-dc9f-43d2-a036-a9afc089388c">

The file tree now shows which files/folders have comments in them. To do this, I had to rework the cache to have layered keys depending on the path parts (so i could propagate upwards and quickly check if the folder has subcontents with comments). 

The cache also has a new function to remove empty keys. Previously, I just had "deleted" comments be an empty string, then ignored the empty string. Now, if a key has no value, that key is removed from the object. Then we check its parent to see if it still has values. This is much more like a proper cache.

the tree decorators are updated on load of the extension, when a new comment is made, when a comment is deleted, or when text editors are swapped.

The decorators are also quite easy to extend. When linting becomes a thing, we can have multiple decorators (i think up to 2 characters at a time) on a single file.

