### PR TITLE
Various delete comment methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
         {
           "command": "assay.openInDiffTool",
           "when": "false"
+        },
+        {
+          "command": "assay.welcome",
+          "when": "false"
         }
       ],
       "explorer/context": [
@@ -53,6 +57,11 @@
           "when": "editorTextFocus",
           "command": "assay.codeComment",
           "group": "navigation"
+        },
+        {
+          "when": "editorTextFocus",
+          "command": "assay.deleteComment",
+          "group": "navigation"
         }
       ]
     },
@@ -67,7 +76,7 @@
     "commands": [
       {
         "command": "assay.welcome",
-        "title": "Assay Introduction"
+        "title": "(Assay) Introduction"
       },
       {
         "command": "assay.openInDiffTool",
@@ -84,6 +93,10 @@
       {
         "command": "assay.exportCommentsFromFolder",
         "title": "(Assay) Export Comments"
+      },
+      {
+        "command": "assay.deleteComment",
+        "title": "(Assay) Delete Comment"
       }
     ]
   },

--- a/src/commands/deleteComment.ts
+++ b/src/commands/deleteComment.ts
@@ -1,0 +1,23 @@
+import { loadFileComments } from "./loadComments";
+import { addToCache } from "../utils/addonCache";
+import { getLineInfo } from "../utils/lineComment";
+import { getRootFolderPath } from "../utils/reviewRootDir";
+
+export async function removeCommentFromCurrentLine() {
+  const lineInfo = getLineInfo();
+  if (!lineInfo) {
+    return;
+  }
+
+  const fullpath = lineInfo.fullpath;
+  const lineNumber = lineInfo.lineNumber;
+
+  const rootDir = await getRootFolderPath();
+  const relativePath = fullpath.replace(rootDir, "");
+  const guid = relativePath.split("/")[1];
+  const keys = relativePath.split("/").slice(2);
+
+  await addToCache(guid, [...keys, lineNumber], "");
+  await loadFileComments();
+  return true;
+}

--- a/src/commands/makeComment.ts
+++ b/src/commands/makeComment.ts
@@ -83,12 +83,17 @@ export async function getCommentHTML(
       }</textarea>
         <br />
       <button id="submit">Submit</button>
+      <button id="delete">Delete</button>
       <script>
         const vscode = acquireVsCodeApi();
         const submitButton = document.getElementById("submit");
+        const deleteButton = document.getElementById("delete");
         const comment = document.getElementById("comment");
         submitButton.addEventListener("click", () => {
             vscode.postMessage({ command: 'closePanel', comment: comment.value});
+        });
+        deleteButton.addEventListener("click", () => {
+            vscode.postMessage({ command: 'closePanel', comment: ""});
         });
       </script>
     </body>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { Uri } from "vscode";
 
+import { removeCommentFromCurrentLine } from "./commands/deleteComment";
 import {
   exportCommentsFromFile,
   exportCommentsFromFolderPath,
@@ -97,6 +98,13 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   );
 
+  const deleteCommentDisposable = vscode.commands.registerCommand(
+    "assay.deleteComment",
+    async () => {
+      await removeCommentFromCurrentLine();
+    }
+  );
+
   context.subscriptions.push(
     reviewDisposable,
     welcomeDisposable,
@@ -114,7 +122,8 @@ export async function activate(context: vscode.ExtensionContext) {
     ),
     exportCommentsFileDisposable,
     exportCommentsFolderDisposable,
-    vscode.window.registerFileDecorationProvider(fileDecorator)
+    vscode.window.registerFileDecorationProvider(fileDecorator),
+    deleteCommentDisposable
   );
 }
 

--- a/test/suite/commands/deleteComment.test.ts
+++ b/test/suite/commands/deleteComment.test.ts
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import { describe, it, afterEach } from "mocha";
+import * as sinon from "sinon";
+
+import { removeCommentFromCurrentLine } from "../../../src/commands/deleteComment";
+import * as addonCache from "../../../src/utils/addonCache";
+import * as lineComment from "../../../src/utils/lineComment";
+import * as reviewRootDir from "../../../src/utils/reviewRootDir";
+
+describe("deleteComment.ts", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+  describe("removeCommentFromCurrentLine()", () => {
+    it("should return undefined if there is no line info", async () => {
+      sinon.stub(lineComment, "getLineInfo").returns(undefined);
+      const result = await removeCommentFromCurrentLine();
+      expect(result).to.be.undefined;
+    });
+
+    it("should add an empty string to cache and return true", async () => {
+        const addToCacheStub = sinon.stub(addonCache, "addToCache");
+        const rootFolderPathStub = sinon.stub(reviewRootDir, "getRootFolderPath");
+        rootFolderPathStub.resolves("/root");
+        sinon.stub(lineComment, "getLineInfo").returns({
+            fullpath: "/root/test-guid/0.1.0/file",
+            lineNumber: "1",
+        });
+        const result = await removeCommentFromCurrentLine();
+        expect(result).to.be.true;
+        expect(addToCacheStub.calledOnce).to.be.true;
+        expect(addToCacheStub.calledWith("test-guid", ["0.1.0", "file", "1"], "")).to.be.true;
+    });
+  });
+});

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -16,7 +16,7 @@ describe("extension.ts", () => {
     expect(commands).to.include.members(["assay.get"]);
     expect(commands).to.include.members(["assay.welcome"]);
     expect(commands).to.include.members(["assay.review"]);
-    expect(context.subscriptions.length).to.equal(13);
+    expect(context.subscriptions.length).to.equal(14);
   });
 
   it("should deactivate and return undefined", async () => {


### PR DESCRIPTION
You are now able to delete comments:

1. from the command palette. will remove the comment from the current line
2. from the context menu
3. from the make comment webview.

this works by making the comment of the current line blank, which `removeEmptyObjectsFromCache()` will catch and remove. Then it reloads the comments.

(also remove the assay introduction from the command palette for now)