### PR TITLE
Support vscode:// urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "assay",
   "displayName": "assay",
+  "publisher": "mozilla",
   "description": "A Firefox Addons review tool disguised as a VSCode exention.",
   "version": "0.0.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": ["onUri"],
   "main": "./dist/extension.js",
   "contributes": {
     "configuration": {

--- a/src/commands/getAddon.ts
+++ b/src/commands/getAddon.ts
@@ -20,13 +20,16 @@ export async function getInput(): Promise<string> {
   return input;
 }
 
-export async function downloadAndExtract() {
+export async function downloadAndExtract(
+  urlGuid?: string,
+  urlVersion?: string
+) {
   try {
-    const input = await getInput();
+    const input = urlGuid || (await getInput());
 
     const json: addonInfoResponse = await getAddonInfo(input);
 
-    const versionInfo = await getVersionChoice(input);
+    const versionInfo = await getVersionChoice(input, urlVersion);
     const addonFileId = versionInfo.fileID;
     const addonVersion = versionInfo.version;
     const addonGUID = json.guid;

--- a/src/commands/loadComments.ts
+++ b/src/commands/loadComments.ts
@@ -22,7 +22,7 @@ export async function loadFileComments() {
   const fullPath = doc.uri.fsPath;
   const rootFolder = await getRootFolderPath();
   if (!fullPath.startsWith(rootFolder)) {
-    throw new Error("File is not in the root folder");
+    return;
   }
 
   const relativePath = fullPath.replace(rootFolder, "");

--- a/src/commands/openFromUrl.ts
+++ b/src/commands/openFromUrl.ts
@@ -1,3 +1,4 @@
+import * as fs from "fs";
 import * as vscode from "vscode";
 
 import { downloadAndExtract } from "./getAddon";
@@ -8,7 +9,7 @@ export async function handleReviewUrl(guid: string, version: string) {
   const rootPath = await getRootFolderPath();
   const addonVersionManifestPath = `${rootPath}/${guid}/${version}/manifest.json`;
   try {
-    await vscode.workspace.fs.stat(vscode.Uri.file(addonVersionManifestPath));
+    await fs.promises.stat(addonVersionManifestPath);
   } catch (error) {
     await downloadAndExtract(guid, version);
   }

--- a/src/commands/openFromUrl.ts
+++ b/src/commands/openFromUrl.ts
@@ -1,0 +1,30 @@
+import * as vscode from "vscode";
+
+import { downloadAndExtract } from "./getAddon";
+import { getRootFolderPath } from "../utils/reviewRootDir";
+
+// handles urls of the form /review/<guid>/<version>
+export async function handleReviewUrl(guid: string, version: string) {
+  const rootPath = await getRootFolderPath();
+  const addonVersionManifestPath = `${rootPath}/${guid}/${version}/manifest.json`;
+  try {
+    await vscode.workspace.fs.stat(vscode.Uri.file(addonVersionManifestPath));
+  } catch (error) {
+    await downloadAndExtract(guid, version);
+  }
+
+  const addonManifestUri = vscode.Uri.file(addonVersionManifestPath);
+  await vscode.window.showTextDocument(addonManifestUri);
+}
+
+// handles vscode://mozilla.assay/... urls
+export async function handleUri(uri: vscode.Uri) {
+  const { path } = uri;
+  const action = path.split("/")[1];
+
+  if (action === "review") {
+    const guid = path.split("/")[2];
+    const version = path.split("/")[3];
+    await handleReviewUrl(guid, version);
+  }
+}

--- a/src/commands/openFromUrl.ts
+++ b/src/commands/openFromUrl.ts
@@ -21,11 +21,10 @@ export async function handleReviewUrl(guid: string, version: string) {
 // handles vscode://mozilla.assay/... urls
 export async function handleUri(uri: vscode.Uri) {
   const { path } = uri;
-  const action = path.split("/")[1];
+  const [_, action, ...rest] = path.split("/");
 
   if (action === "review") {
-    const guid = path.split("/")[2];
-    const version = path.split("/")[3];
+    const [guid, version] = rest;
     await handleReviewUrl(guid, version);
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { getApiKeyFromUser, getSecretFromUser } from "./commands/getApiCreds";
 import { openInDiffTool } from "./commands/launchDiff";
 import { loadFileComments } from "./commands/loadComments";
 import { makeComment } from "./commands/makeComment";
+import { handleUri } from "./commands/openFromUrl";
 import { updateTaskbar } from "./commands/updateTaskbar";
 import {
   setExtensionSecretStorage,
@@ -29,6 +30,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // load comments on startup/reload
   await loadFileComments();
+
+  // listen for vscode://publisher.assay/ links
+  const UriHandlerDisposable = vscode.window.registerUriHandler({
+    handleUri,
+  });
 
   const reviewDisposable = vscode.commands.registerCommand(
     "assay.review",
@@ -98,6 +104,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(
+    UriHandlerDisposable,
     reviewDisposable,
     welcomeDisposable,
     getDisposable,

--- a/src/utils/addonVersions.ts
+++ b/src/utils/addonVersions.ts
@@ -47,7 +47,8 @@ export async function getAddonVersions(input: string, next?: string) {
 }
 
 export async function getVersionChoice(
-  input: string
+  input: string,
+  urlVersion?: string
 ): Promise<{ fileID: string; version: string }> {
   const versions: addonVersion[] = [];
   let next: string | undefined = undefined;
@@ -64,9 +65,12 @@ export async function getVersionChoice(
     const versionItems = versions.map((version) => version.version);
     next ? versionItems.push("More") : null;
 
-    const choice = await vscode.window.showQuickPick(versionItems, {
-      placeHolder: "Choose a version",
-    });
+    // if opened from a vscode:// link, use the version from the link
+    const choice =
+      urlVersion ||
+      (await vscode.window.showQuickPick(versionItems, {
+        placeHolder: "Choose a version",
+      }));
 
     if (choice === "More") {
       continue;

--- a/test/suite/commands/getAddon.test.ts
+++ b/test/suite/commands/getAddon.test.ts
@@ -3,7 +3,8 @@ import { describe, it, afterEach } from "mocha";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 
-import { getInput } from "../../../src/commands/getAddon";
+import { getInput, downloadAndExtract } from "../../../src/commands/getAddon";
+import * as addonInfo from "../../../src/utils/addonInfo";
 
 describe("getAddon.ts", async () => {
   afterEach(() => {
@@ -26,6 +27,31 @@ describe("getAddon.ts", async () => {
       } catch (error) {
         expect(error).to.be.an("error");
       }
+    });
+  });
+
+  describe("downloadAndExtract()", () => {
+    it("should use the guid parameter and not call getInput()", async () => {
+      // stub getAddonInfo
+      const getAddonInfoStub = sinon.stub(addonInfo, "getAddonInfo");
+      getAddonInfoStub.resolves({
+        slug: "test-slug",
+        name: {
+          en_US: "Test Slug",
+        },
+        guid: "test-guid",
+        review_url: "test-review-url",
+        default_locale: "en_US",
+        current_version: {
+          version: "1.0",
+          file: {
+            id: "1",
+          },
+        },
+      });
+
+      await downloadAndExtract("test-guid");
+      expect(getAddonInfoStub.calledWith("test-guid")).to.be.true;
     });
   });
 });

--- a/test/suite/commands/openFromUrl.test.ts
+++ b/test/suite/commands/openFromUrl.test.ts
@@ -55,5 +55,34 @@ describe("openFromUrl.ts", async () => {
       expect(downloadAndExtractStub.called).to.be.true;
       expect(showTextDocumentStub.called).to.be.true;
     });
+
+    it("should not fail the stat check and not call downloadAndExtract()", async () => {
+      const uri = {
+        path: "/review/test-guid/test-version",
+      };
+      const getRootFolderPathStub = sinon.stub(
+        reviewRootDir,
+        "getRootFolderPath"
+      );
+      getRootFolderPathStub.resolves("test-root-folder-path");
+
+      const fsStatStub = sinon.stub(fs.promises, "stat");
+      fsStatStub.resolves();
+
+      const downloadAndExtractStub = sinon.stub(
+        getAddonFunctions,
+        "downloadAndExtract"
+      );
+
+      const showTextDocumentStub = sinon.stub(
+        vscode.window,
+        "showTextDocument"
+      );
+      showTextDocumentStub.resolves();
+
+      await handleUri(uri as any);
+      expect(showTextDocumentStub.called).to.be.true;
+      expect(downloadAndExtractStub.called).to.be.false;
+    });
   });
 });

--- a/test/suite/commands/openFromUrl.test.ts
+++ b/test/suite/commands/openFromUrl.test.ts
@@ -1,0 +1,59 @@
+import { expect } from "chai";
+import * as fs from "fs";
+import { describe, it, afterEach } from "mocha";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+
+import * as getAddonFunctions from "../../../src/commands/getAddon";
+import { handleReviewUrl, handleUri } from "../../../src/commands/openFromUrl";
+import * as reviewRootDir from "../../../src/utils/reviewRootDir";
+
+describe("openFromUrl.ts", async () => {
+  afterEach(async () => {
+    sinon.restore();
+  });
+
+  describe("handleUri()", async () => {
+    it("should do nothing if the action is not review", async () => {
+      const uri = {
+        path: "/test-action/test-guid/test-version",
+      };
+      const getRootFolderPathStub = sinon.stub(
+        reviewRootDir,
+        "getRootFolderPath"
+      );
+      await handleUri(uri as any);
+      expect(getRootFolderPathStub.called).to.be.false;
+    });
+
+    it("should fail the stat check and call downloadAndExtract() if the manifest does not exist", async () => {
+      const uri = {
+        path: "/review/test-guid/test-version",
+      };
+      const getRootFolderPathStub = sinon.stub(
+        reviewRootDir,
+        "getRootFolderPath"
+      );
+      getRootFolderPathStub.resolves("test-root-folder-path");
+
+      const fsStatStub = sinon.stub(fs.promises, "stat");
+      fsStatStub.rejects();
+
+      const downloadAndExtractStub = sinon.stub(
+        getAddonFunctions,
+        "downloadAndExtract"
+      );
+      downloadAndExtractStub.resolves();
+
+      const showTextDocumentStub = sinon.stub(
+        vscode.window,
+        "showTextDocument"
+      );
+      showTextDocumentStub.resolves();
+
+      await handleUri(uri as any);
+      expect(downloadAndExtractStub.called).to.be.true;
+      expect(showTextDocumentStub.called).to.be.true;
+    });
+  });
+});

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -16,7 +16,7 @@ describe("extension.ts", () => {
     expect(commands).to.include.members(["assay.get"]);
     expect(commands).to.include.members(["assay.welcome"]);
     expect(commands).to.include.members(["assay.review"]);
-    expect(context.subscriptions.length).to.equal(13);
+    expect(context.subscriptions.length).to.be.greaterThan(10);
   });
 
   it("should deactivate and return undefined", async () => {

--- a/test/suite/utils/addonVersions.test.ts
+++ b/test/suite/utils/addonVersions.test.ts
@@ -75,6 +75,27 @@ describe("addonVersions.ts", () => {
         expect(version?.version).to.equal("1");
       });
     });
+
+    it("should pick the version from the input parameter", async () => {
+      const fetchStub = sinon.stub();
+      fetchStub.onCall(0).returns({
+        json: () => {
+          return {
+            results: firstVersions,
+          };
+        },
+      });
+      sinon.replace(fetch, "default", fetchStub as any);
+
+      const showQuickPickStub = sinon.stub();
+      showQuickPickStub.onCall(0).returns("1");
+      sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
+
+      getVersionChoice("addon-slug-or-guid", "2").then((version) => {
+        expect(version?.fileID).to.equal("2");
+        expect(version?.version).to.equal("2");
+      });
+    });
   });
 
   describe("getPaginatedVersions()", () => {
@@ -181,7 +202,10 @@ describe("addonVersions.ts", () => {
       });
       sinon.replace(fetch, "default", fetchStub as any);
 
-      const showErrorMessageStub = sinon.stub(vscode.window, "showErrorMessage");
+      const showErrorMessageStub = sinon.stub(
+        vscode.window,
+        "showErrorMessage"
+      );
       showErrorMessageStub.onCall(0).resolves({ title: "Cancel" });
 
       try {


### PR DESCRIPTION
This works by using registerUriHandler to transfer information from the browser to vscode. the link looks like `vscode://mozilla.assay/review/guid/version`

It will check to see if the manifest of the version exists in the set root path. If not, it will automatically download it and open it. if the version or guid is not specified, asks for those values after clicking the link.