### PR TITLE
Updating assay version

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,10 @@
       {
         "command": "assay.deleteComment",
         "title": "(Assay) Delete Comment"
+      },
+      {
+        "command": "assay.checkForUpdates",
+        "title": "(Assay) Check For Updates"
       }
     ]
   },

--- a/src/commands/updateAssay.ts
+++ b/src/commands/updateAssay.ts
@@ -85,9 +85,9 @@ export async function installNewVersion(downloadUrl: string, version: string) {
     fs.unlinkSync(savePath);
 
     vscode.window.showInformationMessage(
-      `Assay updated to version ${version}. Please reload VSCode.`,
-      "Reload"
+      `Assay updated to version ${version}. Please reload VSCode.`
     );
+
     return true;
   });
 }

--- a/src/commands/updateAssay.ts
+++ b/src/commands/updateAssay.ts
@@ -1,11 +1,12 @@
 import { spawn } from "child_process";
+import * as fs from "fs";
 import fetch from "node-fetch";
+import path = require("path");
 import * as vscode from "vscode";
 
 import { showErrorMessage } from "../utils/processErrors";
 
-export async function newVersion() {
-  // check the github page to see if there is a new release
+export async function checkGetNewVersion() {
   const apiUrl = `https://api.github.com/repos/mozilla/assay/releases/latest`;
   const response = await fetch(apiUrl);
 
@@ -21,28 +22,86 @@ export async function newVersion() {
     vscode.extensions.getExtension("mozilla.assay")?.packageJSON.version;
 
   if (latestVersion !== currentVersion) {
-    return json.assets[0].browser_download_url;
+    return {
+      downloadLink: json.assets[0].browser_download_url,
+      version: latestVersion,
+    };
   }
 
   return false;
 }
 
-export async function installNewVersion(downloadUrl: string) {
-  const downloadProcess = spawn("code", ["--install-extension", downloadUrl]);
-  downloadProcess.on("error", (err) => {
-    vscode.window.showErrorMessage(
-      `Assay failed to install new version: ${err.message}`
+export async function downloadVersion(downloadUrl: string) {
+  return await vscode.window.withProgress(
+    { title: "Assay", location: vscode.ProgressLocation.Notification },
+    async function (progress) {
+      progress.report({
+        message: "Downloading Version",
+      });
+
+      const response = await fetch(downloadUrl);
+      if (!response.ok) {
+        throw new Error(
+          `Could not fetch latest version from GitHub: ${response.statusText}`
+        );
+      }
+
+      const extensionPath =
+        vscode.extensions.getExtension("mozilla.assay")?.extensionPath;
+      if (!extensionPath) {
+        throw new Error("Could not find extension path");
+      }
+      const savePath = path.join(extensionPath, "version.vsix");
+
+      const dest = fs.createWriteStream(savePath, { flags: "w" });
+      dest.write(await response.buffer());
+      dest.close();
+
+      if (!fs.existsSync(savePath)) {
+        const errorMessages = {
+          window: {
+            other: `Could not download addon to ${downloadUrl}`,
+          },
+          thrown: {
+            other: "Download failed",
+          },
+        };
+
+        return await showErrorMessage(errorMessages, "other", downloadVersion, [
+          downloadUrl,
+        ]);
+      }
+
+      return savePath;
+    }
+  );
+}
+
+export async function installNewVersion(downloadUrl: string, version: string) {
+  const savePath = await downloadVersion(downloadUrl);
+  const downloadProcess = spawn("code", ["--install-extension", savePath]);
+
+  downloadProcess.on("exit", (code) => {
+    if (code !== 0) {
+      throw new Error(`Could not install addon`);
+    }
+    fs.unlinkSync(savePath);
+    const currentVersion =
+      vscode.extensions.getExtension("mozilla.assay")?.packageJSON.version;
+    console.log(currentVersion, version);
+
+    vscode.window.showInformationMessage(
+      `Assay updated to version ${version} (from ${currentVersion})`
     );
-    return;
   });
-  return true;
 }
 
 export async function updateAssay() {
-  const newVersionLink = await newVersion();
-  if (newVersionLink && (await installNewVersion(newVersionLink))) {
-    vscode.window.showInformationMessage(
-      `Assay has been updated to version ${newVersionLink}, please restart VSCode to complete the update.`
-    );
+  const downloadInfo = await checkGetNewVersion();
+  if (!downloadInfo) {
+    return;
   }
+  const versionLink = downloadInfo.downloadLink;
+  const version = downloadInfo.version;
+  await installNewVersion(versionLink, version);
 }

--- a/src/commands/updateAssay.ts
+++ b/src/commands/updateAssay.ts
@@ -6,7 +6,7 @@ import * as vscode from "vscode";
 
 import { showErrorMessage } from "../utils/processErrors";
 
-export async function checkGetNewVersion() {
+export async function checkAndGetNewVersion() {
   const apiUrl = `https://api.github.com/repos/mozilla/assay/releases/latest`;
   const response = await fetch(apiUrl);
 
@@ -86,22 +86,19 @@ export async function installNewVersion(downloadUrl: string, version: string) {
       throw new Error(`Could not install addon`);
     }
     fs.unlinkSync(savePath);
-    const currentVersion =
-      vscode.extensions.getExtension("mozilla.assay")?.packageJSON.version;
-    console.log(currentVersion, version);
 
     vscode.window.showInformationMessage(
-      `Assay updated to version ${version} (from ${currentVersion})`
+      `Assay updated to version ${version}. Please reload VSCode.`
     );
   });
 }
 
 export async function updateAssay() {
-  const downloadInfo = await checkGetNewVersion();
+  const downloadInfo = await checkAndGetNewVersion();
   if (!downloadInfo) {
     return;
   }
   const versionLink = downloadInfo.downloadLink;
   const version = downloadInfo.version;
-  await installNewVersion(versionLink, version);
+  installNewVersion(versionLink, version);
 }

--- a/src/commands/updateAssay.ts
+++ b/src/commands/updateAssay.ts
@@ -1,0 +1,48 @@
+import { spawn } from "child_process";
+import fetch from "node-fetch";
+import * as vscode from "vscode";
+
+import { showErrorMessage } from "../utils/processErrors";
+
+export async function newVersion() {
+  // check the github page to see if there is a new release
+  const apiUrl = `https://api.github.com/repos/mozilla/assay/releases/latest`;
+  const response = await fetch(apiUrl);
+
+  if (!response.ok) {
+    throw new Error(
+      `Could not fetch latest version from GitHub: ${response.statusText}`
+    );
+  }
+
+  const json = await response.json();
+  const latestVersion = json.tag_name;
+  const currentVersion =
+    vscode.extensions.getExtension("mozilla.assay")?.packageJSON.version;
+
+  if (latestVersion !== currentVersion) {
+    return json.assets[0].browser_download_url;
+  }
+
+  return false;
+}
+
+export async function installNewVersion(downloadUrl: string) {
+  const downloadProcess = spawn("code", ["--install-extension", downloadUrl]);
+  downloadProcess.on("error", (err) => {
+    vscode.window.showErrorMessage(
+      `Assay failed to install new version: ${err.message}`
+    );
+    return;
+  });
+  return true;
+}
+
+export async function updateAssay() {
+  const newVersionLink = await newVersion();
+  if (newVersionLink && (await installNewVersion(newVersionLink))) {
+    vscode.window.showInformationMessage(
+      `Assay has been updated to version ${newVersionLink}, please restart VSCode to complete the update.`
+    );
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { openInDiffTool } from "./commands/launchDiff";
 import { loadFileComments } from "./commands/loadComments";
 import { makeComment } from "./commands/makeComment";
 import { handleUri } from "./commands/openFromUrl";
+import { updateAssay } from "./commands/updateAssay";
 import { updateTaskbar } from "./commands/updateTaskbar";
 import {
   setExtensionSecretStorage,
@@ -36,6 +37,13 @@ export async function activate(context: vscode.ExtensionContext) {
   const UriHandlerDisposable = vscode.window.registerUriHandler({
     handleUri,
   });
+
+  const assayUpdaterDisposable = vscode.commands.registerCommand(
+    "assay.checkForUpdates",
+    async () => {
+      await updateAssay();
+    }
+  );
 
   const reviewDisposable = vscode.commands.registerCommand(
     "assay.review",
@@ -130,7 +138,8 @@ export async function activate(context: vscode.ExtensionContext) {
     exportCommentsFileDisposable,
     exportCommentsFolderDisposable,
     vscode.window.registerFileDecorationProvider(fileDecorator),
-    deleteCommentDisposable
+    deleteCommentDisposable,
+    assayUpdaterDisposable
   );
 }
 

--- a/src/utils/addonCache.ts
+++ b/src/utils/addonCache.ts
@@ -5,12 +5,12 @@ import { getExtensionStoragePath } from "../config/globals";
 
 /***
  * The cache folder is stored at
- * ../Code/User/globalStorage/undefined_publisher.assay/.cache
- * Upon initialization, the extension folder, undefined_publisher.assay,
+ * ../Code/User/globalStorage/mozilla.assay/.cache
+ * Upon initialization, the extension folder, mozilla.assay,
  * may not exist. This function creates that folder and the cache folder
  * if they do not exist.
  *
- * The folder undefined_publisher.assay will continue to exist after this.
+ * The folder mozilla.assay will continue to exist after this.
  */
 export async function addToCache(
   addonGUID: string,

--- a/test/suite/commands/updateAssay.test.ts
+++ b/test/suite/commands/updateAssay.test.ts
@@ -1,5 +1,9 @@
 import { expect } from "chai";
+import * as child_process from "child_process";
+import * as fs from "fs";
 import { describe, it, afterEach, beforeEach } from "mocha";
+import * as node_fetch from "node-fetch";
+import * as path from "path";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 
@@ -14,12 +18,265 @@ describe("updateAssay.ts", () => {
   afterEach(() => {
     sinon.restore();
   });
-  
-  describe("updateAssay()", () => {});
 
-  describe("checkAndGetNewVersion()", () => {});
+  describe("updateAssay()", () => {
+    it("should return false if the version is up to date", async () => {
+      const fetchStub = sinon.stub();
+      fetchStub.resolves({
+        ok: true,
+        json: () => {
+          return { tag_name: "1.0.0" };
+        },
+      } as any);
+      sinon.replace(node_fetch, "default", fetchStub as any);
 
-  describe("installNewVersion()", () => {});
+      const getExtensionStub = sinon.stub(vscode.extensions, "getExtension");
+      getExtensionStub.returns({ packageJSON: { version: "1.0.0" } } as any);
 
-  describe("downloadVersion()", () => {});
+      expect(await updateAssay()).to.equal(false);
+    });
+  });
+
+  describe("checkAndGetNewVersion()", () => {
+    it("should throw an error if the request fails", async () => {
+      const fetchStub = sinon.stub();
+      fetchStub.resolves({ ok: false, statusText: "test" } as any);
+      sinon.replace(node_fetch, "default", fetchStub as any);
+
+      try {
+        await checkAndGetNewVersion();
+        expect.fail("Should have thrown an error");
+      } catch (err: any) {
+        expect(err.message).to.equal(
+          "Could not fetch latest version from GitHub: test"
+        );
+      }
+    });
+
+    it("should return false if the version is up to date", async () => {
+      const fetchStub = sinon.stub();
+      fetchStub.resolves({
+        ok: true,
+        json: () => {
+          return { tag_name: "1.0.0" };
+        },
+      } as any);
+      sinon.replace(node_fetch, "default", fetchStub as any);
+
+      const getExtensionStub = sinon.stub(vscode.extensions, "getExtension");
+      getExtensionStub.returns({ packageJSON: { version: "1.0.0" } } as any);
+
+      const showInformationMessageStub = sinon.stub(
+        vscode.window,
+        "showInformationMessage"
+      );
+      showInformationMessageStub.resolves();
+
+      const result = await checkAndGetNewVersion();
+      expect(result).to.equal(false);
+      expect(showInformationMessageStub.calledOnce).to.equal(true);
+    });
+
+    it("should return the download link and version if the version is not up to date", async () => {
+      const fetchStub = sinon.stub();
+      fetchStub.resolves({
+        ok: true,
+        json: () => {
+          return {
+            tag_name: "1.0.1",
+            assets: [{ browser_download_url: "test" }],
+          };
+        },
+      } as any);
+      sinon.replace(node_fetch, "default", fetchStub as any);
+
+      const getExtensionStub = sinon.stub(vscode.extensions, "getExtension");
+      getExtensionStub.returns({ packageJSON: { version: "1.0.0" } } as any);
+
+      const result = await checkAndGetNewVersion();
+      expect(result).to.deep.equal({
+        downloadLink: "test",
+        version: "1.0.1",
+      });
+    });
+  });
+
+  describe("installNewVersion()", () => {
+    const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
+    beforeEach(async () => {
+      if (!fs.existsSync(workspaceFolder)) {
+        fs.mkdirSync(workspaceFolder);
+      }
+      const fetchStub = sinon.stub();
+      fetchStub.resolves({
+        ok: true,
+        buffer: () => {
+          return "test";
+        },
+      } as any);
+      sinon.replace(node_fetch, "default", fetchStub as any);
+
+      const getExtensionStub = sinon.stub(vscode.extensions, "getExtension");
+      getExtensionStub.returns({ extensionPath: workspaceFolder } as any);
+    });
+
+    afterEach(() => {
+      if (fs.existsSync(workspaceFolder)) {
+        fs.rmdirSync(workspaceFolder, { recursive: true });
+      }
+    });
+
+    it("should spawn a new process to install the new version and remove the file when done", async () => {
+      const spawnStub = sinon.stub(child_process, "spawn");
+      const event = {
+        on: sinon.stub().callsFake(async (event, callback) => {
+          if (event === "exit") {
+            callback(0); // Simulate a successful installation with exit code 0
+          }
+        }),
+      };
+      spawnStub.returns(event as any);
+
+      const unlinkSyncStub = sinon.stub(fs, "unlinkSync");
+      unlinkSyncStub.returns(undefined);
+
+      const showInformationMessageStub = sinon.stub(
+        vscode.window,
+        "showInformationMessage"
+      );
+      showInformationMessageStub.resolves();
+
+      await installNewVersion("test", "1.0.0");
+      expect(spawnStub.calledOnce).to.equal(true);
+      expect(
+        spawnStub.calledWith("code", [
+          "--install-extension",
+          `${workspaceFolder}/version.vsix`,
+        ])
+      ).to.equal(true);
+      expect(unlinkSyncStub.calledOnce).to.equal(true);
+      expect(
+        unlinkSyncStub.calledWith(`${workspaceFolder}/version.vsix`)
+      ).to.equal(true);
+      expect(showInformationMessageStub.calledOnce).to.equal(true);
+      expect(
+        showInformationMessageStub.calledWith(
+          "Assay updated to version 1.0.0. Please reload VSCode."
+        )
+      ).to.equal(true);
+    });
+
+    it("should throw an error if the installation fails", async () => {
+      const spawnStub = sinon.stub(child_process, "spawn");
+      const event = {
+        on: sinon.stub().callsFake(async (event, callback) => {
+          if (event === "exit") {
+            callback(1);
+          }
+        }),
+      };
+      spawnStub.returns(event as any);
+
+      const showErrorMessageStub = sinon.stub(
+        vscode.window,
+        "showErrorMessage"
+      );
+      showErrorMessageStub.resolves();
+      await installNewVersion("test", "1.0.0");
+      expect(showErrorMessageStub.calledOnce).to.equal(true);
+      expect(
+        showErrorMessageStub.calledWith(
+          "Assay could not be updated to version 1.0.0. Please try again."
+        )
+      ).to.equal(true);
+    });
+  });
+
+  describe("downloadVersion()", () => {
+    it("should throw an error if the request fails", async () => {
+      const fetchStub = sinon.stub();
+      fetchStub.resolves({ ok: false, statusText: "test" } as any);
+      sinon.replace(node_fetch, "default", fetchStub as any);
+
+      try {
+        await downloadVersion("test");
+        expect.fail("Should have thrown an error");
+      } catch (err: any) {
+        expect(err.message).to.equal(
+          "Could not fetch version file from GitHub: test"
+        );
+      }
+    });
+
+    it("should throw an error if the extension path cannot be found", async () => {
+      const fetchStub = sinon.stub();
+      fetchStub.resolves({
+        ok: true,
+        buffer: () => {
+          return "test";
+        },
+      } as any);
+      sinon.replace(node_fetch, "default", fetchStub as any);
+
+      const getExtensionStub = sinon.stub(vscode.extensions, "getExtension");
+      getExtensionStub.returns(undefined);
+
+      try {
+        await downloadVersion("test");
+        expect.fail("Should have thrown an error");
+      } catch (err: any) {
+        expect(err.message).to.equal("Could not find extension path");
+      }
+    });
+
+    it("should throw an error if the file cannot be saved", async () => {
+      const fetchStub = sinon.stub();
+      fetchStub.resolves({
+        ok: true,
+        buffer: () => {
+          return "test";
+        },
+      } as any);
+      sinon.replace(node_fetch, "default", fetchStub as any);
+
+      const getExtensionStub = sinon.stub(vscode.extensions, "getExtension");
+      getExtensionStub.returns({ extensionPath: "test" } as any);
+
+      const createWriteStreamStub = sinon.stub(fs, "createWriteStream");
+      createWriteStreamStub.throws(new Error("test"));
+
+      try {
+        await downloadVersion("test");
+        expect.fail("Should have thrown an error");
+      } catch (err: any) {
+        expect(err.message).to.equal("Could not write version file: test");
+      }
+    });
+
+    it("should return the save path if the file is saved", async () => {
+      const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
+      if (!fs.existsSync(workspaceFolder)) {
+        fs.mkdirSync(workspaceFolder);
+      }
+      const fetchStub = sinon.stub();
+      fetchStub.resolves({
+        ok: true,
+        buffer: () => {
+          return "test";
+        },
+      } as any);
+      sinon.replace(node_fetch, "default", fetchStub as any);
+
+      const getExtensionStub = sinon.stub(vscode.extensions, "getExtension");
+      getExtensionStub.returns({ extensionPath: workspaceFolder } as any);
+
+      const returnedPath = await downloadVersion("test");
+      expect(returnedPath).to.equal(
+        path.resolve(workspaceFolder, "version.vsix")
+      );
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(fs.existsSync(returnedPath)).to.equal(true);
+      fs.rmdirSync(workspaceFolder, { recursive: true });
+    });
+  });
 });

--- a/test/suite/commands/updateAssay.test.ts
+++ b/test/suite/commands/updateAssay.test.ts
@@ -1,0 +1,25 @@
+import { expect } from "chai";
+import { describe, it, afterEach, beforeEach } from "mocha";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+
+import {
+  updateAssay,
+  checkAndGetNewVersion,
+  installNewVersion,
+  downloadVersion,
+} from "../../../src/commands/updateAssay";
+
+describe("updateAssay.ts", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+  
+  describe("updateAssay()", () => {});
+
+  describe("checkAndGetNewVersion()", () => {});
+
+  describe("installNewVersion()", () => {});
+
+  describe("downloadVersion()", () => {});
+});

--- a/test/suite/commands/updateAssay.test.ts
+++ b/test/suite/commands/updateAssay.test.ts
@@ -40,7 +40,7 @@ describe("updateAssay.ts", () => {
   describe("checkAndGetNewVersion()", () => {
     it("should throw an error if the request fails", async () => {
       const fetchStub = sinon.stub();
-      fetchStub.resolves({ ok: false, statusText: "test" } as any);
+      fetchStub.resolves({ ok: false, statusText: "error message" } as any);
       sinon.replace(node_fetch, "default", fetchStub as any);
 
       try {
@@ -48,7 +48,7 @@ describe("updateAssay.ts", () => {
         expect.fail("Should have thrown an error");
       } catch (err: any) {
         expect(err.message).to.equal(
-          "Could not fetch latest version from GitHub: test"
+          "Could not fetch latest version from GitHub: error message"
         );
       }
     });
@@ -84,7 +84,7 @@ describe("updateAssay.ts", () => {
         json: () => {
           return {
             tag_name: "1.0.1",
-            assets: [{ browser_download_url: "test" }],
+            assets: [{ browser_download_url: "https://github.com/release/test" }],
           };
         },
       } as any);
@@ -95,7 +95,7 @@ describe("updateAssay.ts", () => {
 
       const result = await checkAndGetNewVersion();
       expect(result).to.deep.equal({
-        downloadLink: "test",
+        downloadLink: "https://github.com/release/test",
         version: "1.0.1",
       });
     });
@@ -111,7 +111,7 @@ describe("updateAssay.ts", () => {
       fetchStub.resolves({
         ok: true,
         buffer: () => {
-          return "test";
+          return "file contents";
         },
       } as any);
       sinon.replace(node_fetch, "default", fetchStub as any);
@@ -146,7 +146,7 @@ describe("updateAssay.ts", () => {
       );
       showInformationMessageStub.resolves();
 
-      await installNewVersion("test", "1.0.0");
+      await installNewVersion("https://github.com/release/test", "1.0.0");
       expect(spawnStub.calledOnce).to.equal(true);
       expect(
         spawnStub.calledWith("code", [
@@ -182,7 +182,7 @@ describe("updateAssay.ts", () => {
         "showErrorMessage"
       );
       showErrorMessageStub.resolves();
-      await installNewVersion("test", "1.0.0");
+      await installNewVersion("https://github.com/release/test", "1.0.0");
       expect(showErrorMessageStub.calledOnce).to.equal(true);
       expect(
         showErrorMessageStub.calledWith(
@@ -195,7 +195,7 @@ describe("updateAssay.ts", () => {
   describe("downloadVersion()", () => {
     it("should throw an error if the request fails", async () => {
       const fetchStub = sinon.stub();
-      fetchStub.resolves({ ok: false, statusText: "test" } as any);
+      fetchStub.resolves({ ok: false, statusText: "error message" } as any);
       sinon.replace(node_fetch, "default", fetchStub as any);
 
       try {
@@ -203,7 +203,7 @@ describe("updateAssay.ts", () => {
         expect.fail("Should have thrown an error");
       } catch (err: any) {
         expect(err.message).to.equal(
-          "Could not fetch version file from GitHub: test"
+          "Could not fetch version file from GitHub: error message"
         );
       }
     });
@@ -213,7 +213,7 @@ describe("updateAssay.ts", () => {
       fetchStub.resolves({
         ok: true,
         buffer: () => {
-          return "test";
+          return "file contents";
         },
       } as any);
       sinon.replace(node_fetch, "default", fetchStub as any);
@@ -222,7 +222,7 @@ describe("updateAssay.ts", () => {
       getExtensionStub.returns(undefined);
 
       try {
-        await downloadVersion("test");
+        await downloadVersion("https://github.com/release/test");
         expect.fail("Should have thrown an error");
       } catch (err: any) {
         expect(err.message).to.equal("Could not find extension path");
@@ -234,22 +234,22 @@ describe("updateAssay.ts", () => {
       fetchStub.resolves({
         ok: true,
         buffer: () => {
-          return "test";
+          return "file contents";
         },
       } as any);
       sinon.replace(node_fetch, "default", fetchStub as any);
 
       const getExtensionStub = sinon.stub(vscode.extensions, "getExtension");
-      getExtensionStub.returns({ extensionPath: "test" } as any);
+      getExtensionStub.returns({ extensionPath: "test/path/" } as any);
 
       const createWriteStreamStub = sinon.stub(fs, "createWriteStream");
-      createWriteStreamStub.throws(new Error("test"));
+      createWriteStreamStub.throws(new Error("error message"));
 
       try {
-        await downloadVersion("test");
+        await downloadVersion("https://github.com/release/test");
         expect.fail("Should have thrown an error");
       } catch (err: any) {
-        expect(err.message).to.equal("Could not write version file: test");
+        expect(err.message).to.equal("Could not write version file: error message");
       }
     });
 
@@ -262,7 +262,7 @@ describe("updateAssay.ts", () => {
       fetchStub.resolves({
         ok: true,
         buffer: () => {
-          return "test";
+          return "file contents";
         },
       } as any);
       sinon.replace(node_fetch, "default", fetchStub as any);
@@ -270,7 +270,7 @@ describe("updateAssay.ts", () => {
       const getExtensionStub = sinon.stub(vscode.extensions, "getExtension");
       getExtensionStub.returns({ extensionPath: workspaceFolder } as any);
 
-      const returnedPath = await downloadVersion("test");
+      const returnedPath = await downloadVersion("https://github.com/release/test");
       expect(returnedPath).to.equal(
         path.resolve(workspaceFolder, "version.vsix")
       );


### PR DESCRIPTION
This allows the user to check for updates with a command. It will check the latest release on github and if the release tag name (in the format x.x.x) does not match our current version number in package.json, will download and install the update. Finally, it will ask the user to reload vscode.

I'm not too familiar with github releases, this change requires the tag name to be formatted like x.x.x not vx.x.x. Is there any style that I should be following?