### PR TITLE
Provide feedback when working with AMO credentails 

### DIFF
--- a/src/commands/getApiCreds.ts
+++ b/src/commands/getApiCreds.ts
@@ -14,7 +14,10 @@ export async function getApiKeyFromUser() {
     ignoreFocusOut: true,
   });
 
-  if (!apiKey) {
+  if (apiKey === undefined) {
+    // User cancelled input
+    return false;
+  } else if (!apiKey) {
     throw new Error("No API Key provided");
   }
 
@@ -41,11 +44,14 @@ export async function getSecretFromUser() {
     ignoreFocusOut: true,
   });
 
-  if (!apiSecret) {
+  if (apiSecret === undefined) {
+    // User cancelled input
+    return false;
+  } else if (!apiSecret) {
     throw new Error("No API Secret provided");
   }
 
-    await secrets.store("amoApiSecret", apiSecret);
+  await secrets.store("amoApiSecret", apiSecret);
   return true;
 }
 

--- a/src/commands/getApiCreds.ts
+++ b/src/commands/getApiCreds.ts
@@ -42,8 +42,11 @@ export async function getCredsFromStorage(): Promise<{
   secret: string;
 }> {
   const secrets = getExtensionSecretStorage();
-  const apiKey = await secrets.get("amoApiKey");
-  const secret = await secrets.get("amoApiSecret");
+
+  const [apiKey, secret] = await Promise.all([
+    secrets.get("amoApiKey"),
+    secrets.get("amoApiSecret")
+  ]);
 
   if (!apiKey || !secret) {
     return await showErrorMessage(

--- a/src/commands/getApiCreds.ts
+++ b/src/commands/getApiCreds.ts
@@ -4,9 +4,13 @@ import { getExtensionSecretStorage } from "../config/globals";
 import { showErrorMessage } from "../utils/processErrors";
 
 export async function getApiKeyFromUser() {
+  const secrets = getExtensionSecretStorage();
+
+  const placeHolder = (await secrets.get("amoApiKey"));
   const apiKey = await vscode.window.showInputBox({
     prompt: "Enter your AMO API Key (e.g. user:12345678:123)",
     title: "AMO API Key",
+    placeHolder,
     ignoreFocusOut: true,
   });
 
@@ -14,16 +18,25 @@ export async function getApiKeyFromUser() {
     throw new Error("No API Key provided");
   }
 
-  const secrets = getExtensionSecretStorage();
-
   await secrets.store("amoApiKey", apiKey);
   return true;
 }
 
+// Generate a shorter version of the secret that we can show to the user
+export function truncateSecret(str: string, size = 4) {
+  const head = str.substring(0, size);
+  const tail = str.substring(str.length - size);
+  return `${head}...${tail}`;
+}
+
 export async function getSecretFromUser() {
+  const secrets = getExtensionSecretStorage();
+  const placeHolder = truncateSecret((await secrets.get("amoApiSecret")) || '');
+
   const apiSecret = await vscode.window.showInputBox({
     prompt: "Enter your AMO API Secret",
     title: "AMO API Secret",
+    placeHolder,
     password: true,
     ignoreFocusOut: true,
   });
@@ -32,8 +45,7 @@ export async function getSecretFromUser() {
     throw new Error("No API Secret provided");
   }
 
-  const secrets = getExtensionSecretStorage();
-  await secrets.store("amoApiSecret", apiSecret);
+    await secrets.store("amoApiSecret", apiSecret);
   return true;
 }
 

--- a/src/commands/getApiCreds.ts
+++ b/src/commands/getApiCreds.ts
@@ -1,7 +1,10 @@
+import fetch from "node-fetch";
 import * as vscode from "vscode";
 
+import constants from "../config/config";
 import { getExtensionSecretStorage } from "../config/globals";
 import { showErrorMessage } from "../utils/processErrors";
+import { makeAuthHeader } from "../utils/requestAuth";
 
 export async function getApiKeyFromUser() {
   const secrets = getExtensionSecretStorage();
@@ -52,6 +55,7 @@ export async function getSecretFromUser() {
   }
 
   await secrets.store("amoApiSecret", apiSecret);
+
   return true;
 }
 
@@ -82,4 +86,21 @@ export async function getCredsFromStorage(): Promise<{
   }
 
   return { apiKey, secret };
+}
+
+export async function testApiCredentials() {
+  const url = `${constants.apiBaseURL}accounts/profile/`;
+  const headers = await makeAuthHeader();
+  const response = await fetch(url, { headers });
+
+  if (response.status === 200) {
+    vscode.window.showInformationMessage("Success! Assay API Key and Secret validated.");
+    return true;
+  } else {
+    vscode.window.showErrorMessage(
+      `Credential test failed: ${response.status} (${response.statusText})`,
+      { title: "Close", isCloseAffordance: true },
+    );
+    return false;
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import {
   exportCommentsFromFolderPath,
 } from "./commands/exportComments";
 import { downloadAndExtract } from "./commands/getAddon";
-import { getApiKeyFromUser, getSecretFromUser } from "./commands/getApiCreds";
+import { getApiKeyFromUser, getSecretFromUser, testApiCredentials } from "./commands/getApiCreds";
 import { openInDiffTool } from "./commands/launchDiff";
 import { loadFileComments } from "./commands/loadComments";
 import { makeComment } from "./commands/makeComment";
@@ -88,6 +88,13 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   );
 
+  const apiCredentialsTestDisposable = vscode.commands.registerCommand(
+    "assay.testApiCredentials",
+    () => {
+      testApiCredentials();
+    }
+  );
+
   const diffDisposable = vscode.commands.registerCommand(
     "assay.openInDiffTool",
     async (_e: Uri, uris?: [Uri, Uri]) => {
@@ -137,6 +144,7 @@ export async function activate(context: vscode.ExtensionContext) {
     getDisposable,
     apiKeyDisposable,
     apiSecretDisposable,
+    apiCredentialsTestDisposable,
     diffDisposable,
     commentDisposable,
     sidebarDisposable,

--- a/src/views/sidebarView.ts
+++ b/src/views/sidebarView.ts
@@ -50,6 +50,14 @@ export class AssayTreeDataProvider
           }
         ),
         new AssayTreeItem(
+          "Test API Credentials",
+          vscode.TreeItemCollapsibleState.None,
+          {
+            command: "assay.testApiCredentials",
+            title: "Test AMO Credentials"
+          }
+        ),
+        new AssayTreeItem(
           "View Instructions",
           vscode.TreeItemCollapsibleState.None,
           {


### PR DESCRIPTION
Currently Assay does not show the user any feedback about any current credentials (API Key, API Secret). Additionally, there is no way to test API credentials save for attempting to use Assay features and having them fail. This make it difficult for the user to debug problems with credentials.

<details><summary><strong>Current UI screenshots</strong></summary>

**Previous version of the Enter API Key UI**
![Screenshot of a VSCode window showing the prompt triggered by invoking the "Enter API Key" command in Assay's command list. This UI contains an empty text box and instructions to "Enter your AMO API Key."](https://github.com/mozilla/assay/assets/1047763/9ae9c6a6-29aa-4160-83db-dde8862c0156)

**Previous version of the Enter API Secret UI**
![Screenshot of a VSCode window showing the prompt triggered by invoking the "Enter API Secret" command in Assay's command list. This UI contains an empty text box and instructions to "Enter your AMO API Secret."](https://github.com/mozilla/assay/assets/1047763/01c61c1d-bc30-4def-9d3d-d52d535b00fb)

</details>

With this PR, Assay will now show the previous API Key and API Secret as placeholder text in the prompts. In the case of the secret, the placeholder value is a truncated version of the string that only revleas the first and last four characters of the secret separated by thee periods. For example, if the secret was `ABCDEFGHIJKLMNOPQRSTUVWXYZ` the placeholder would be `ABCD...WXYZ`. In both cases, the placeholder shows the user what value Assay has stored for the field. This helps remove confusion about whether or not they have already completed this step. The user can cancel input by pressing <kbd>Esc</kbd>. 

This PR also introduces a new command: Test API Credentials. When invoked, this command will use the credentials provided with the other commands to fetch the current user's profile from the API API. If the request completes successfully (response code 200), Assay will show an info notification stating that the credentials have been successfully validated. If the request fails (any other response code), Assay will create an error notification containing the HTTP status code and text. 

<details><summary><strong>Updated UI screenshots</strong></summary>

**Updated version of the Enter API Key UI**
![Screenshot of Assay's updated prompt triggered by invoking the "Enter API Secret". The text box contains placeholder text showing a truncated version of the previous secret value (user:10642996:452) and instructions to "Enter your AMO API Secret."](https://github.com/mozilla/assay/assets/1047763/95f6228d-9809-4da3-9781-581be1fd6e15)

**Updated version of the Enter API Secret UI**
![Screenshot of Assay's updated prompt triggered by invoking the "Enter API Secret". The text box contains placeholder text showing a truncated version of the previous secret value (1277...9228) and instructions to "Enter your AMO API Secret."](https://github.com/mozilla/assay/assets/1047763/69ae8970-f0ab-4eb9-a0a3-a9b5c301ca3e)
 
**Test API Credentials: Success**
![Screenshot of the Test API Credentials command successfully validating the user's credentials. The notification says "Success! Assay API Key and Secret validated."](https://github.com/mozilla/assay/assets/1047763/c1896251-db3e-4a6b-8d5c-d66642051365)

**Test API Credentials: Error**
![Screenshot of the Test API Credentials command failing to validate the user's credentials. The notification says "Credential test failed: 401 (Unauthorized)".](https://github.com/mozilla/assay/assets/1047763/4687a38e-3bb2-4b5a-b053-b43fa7397bd7)

</details>