### PR TITLE
Fixed Issue Where File Decorator Hogs CPU

### DIFF
--- a/src/views/fileDecorations.ts
+++ b/src/views/fileDecorations.ts
@@ -44,7 +44,7 @@ export async function folderHasComment(uri: vscode.Uri) {
   return true;
 }
 
-export class CustomFileDecorationProvider {
+export class CustomFileDecorationProvider implements vscode.FileDecorationProvider {
   private _onDidChangeFileDecorations: vscode.EventEmitter<
     vscode.Uri | vscode.Uri[]
   > = new vscode.EventEmitter<vscode.Uri | vscode.Uri[]>();
@@ -53,23 +53,13 @@ export class CustomFileDecorationProvider {
 
   async provideFileDecoration(uri: vscode.Uri) {
     // if its a file and has a comment, return the decoration
-    // Also if it's a folder of a file that has a comment, return the decoration
-
-    // go up the parent folders until the root too
-    const parentFolder = uri.with({
-      path: uri.path.split("/").slice(0, -1).join("/"),
-    });
-    if (parentFolder.fsPath !== (await getRootFolderPath())) {
-      this.updateDecorations(parentFolder);
-    }
-
     if (
-      (fs.lstatSync(uri.fsPath).isFile() && (await fileHasComment(uri))) ||
-      (fs.lstatSync(uri.fsPath).isDirectory() && (await folderHasComment(uri)))
+      fs.lstatSync(uri.fsPath).isFile() && (await fileHasComment(uri))
     ) {
       return {
         badge: "✎",
         color: new vscode.ThemeColor("charts.green"),
+        propagate: true
       };
     }
   }


### PR DESCRIPTION
Fixes #38.

The deleted code was propagating the edit icon to the parent folders, but provideFileDecoration natively implements the ability to do so by just including propagate: true to the return object.

It no longer shows the icon on folders as propagate overwrites it (so I removed the logic relating to passing the icon to the folder), but it more closely follows VS Code’s native design just leaving this behaviour as is. With the boolean:

<img width="267" alt="image" src="https://github.com/mozilla/assay/assets/44586776/90889f56-995a-4fab-9ab7-cc34faece732">

Versus the original:

<img width="273" alt="image" src="https://github.com/mozilla/assay/assets/44586776/6d5a509c-dbd0-42db-a8f1-6dc25dbe1cdc">

And freshly generated .cpuprofile files to contrast the two:

[Original](https://share.firefox.dev/3WwmNY4) [With change](
https://share.firefox.dev/3yj8tbi)

The class was also missing the 'implements' keyword.
