### PR TITLE
opens manifest.json when version is downloaded or opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "Other"
   ],
   "activationEvents": [
-    "onUri"
+    "onUri",
+    "onStartupFinished"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -36,38 +37,40 @@
     "menus": {
       "explorer/context": [
         {
-          "when": "explorerResourceIsFolder && listDoubleSelection",
+          
           "command": "assay.openInDiffTool",
-          "group": "navigation"
+          "group": "navigation",
+          "when": "assay.commentsEnabled && explorerResourceIsFolder && listDoubleSelection"
         },
         {
-          "when": "explorerResourceIsFolder",
+          
           "command": "assay.exportCommentsFromContext",
-          "group": "navigation"
+          "group": "navigation",
+          "when": "assay.commentsEnabled && explorerResourceIsFolder"
         }
       ],
       "comments/commentThread/title": [
         {
 					"command": "assay.exportComments",
 					"group": "inline@1",
-          "when": "!commentThreadIsEmpty"
+          "when": "assay.commentsEnabled && !commentThreadIsEmpty"
 				},
         {
 					"command": "assay.editComment",
 					"group": "inline@2",
-					"when": "commentController == assay-comments && !commentThreadIsEmpty"
+					"when": "assay.commentsEnabled && commentController == assay-comments && !commentThreadIsEmpty"
 				},
 				{
 					"command": "assay.deleteComment",
 					"group": "inline@3",
-					"when": "commentController == assay-comments && !commentThreadIsEmpty"
+					"when": "assay.commentsEnabled && commentController == assay-comments && !commentThreadIsEmpty"
 				}
       ],
       "comments/commentThread/context": [
 				{
 					"command": "assay.addComment",
 					"group": "inline",
-					"when": "commentController == assay-comments && commentThreadIsEmpty"
+					"when": "assay.commentsEnabled && commentController == assay-comments && commentThreadIsEmpty"
 				}
 			],
 			"comments/comment/title": [
@@ -77,12 +80,12 @@
 				{
 					"command": "assay.cancelSaveComment",
 					"group": "inline@3",
-					"when": "commentController == assay-comments"
+					"when": "assay.commentsEnabled && commentController == assay-comments"
 				},
 				{
 					"command": "assay.saveComment",
 					"group": "inline@2",
-					"when": "commentController == assay-comments"
+					"when": "assay.commentsEnabled && commentController == assay-comments"
 				}
 			]
     },

--- a/src/commands/getAddon.ts
+++ b/src/commands/getAddon.ts
@@ -32,20 +32,26 @@ export async function downloadAndExtract(
 
     const versionInfo = await getVersionChoice(input, urlVersion);
     const addonFileId = versionInfo.fileID;
-    const addonVersion = versionInfo.version;
-    const addonGUID = json.guid;
+    const version = versionInfo.version;
+    const guid = json.guid;
 
     const workspaceFolder = await getRootFolderPath();
-    const compressedFilePath = `${workspaceFolder}/${addonGUID}_${addonVersion}.xpi`;
+    const compressedFilePath = `${workspaceFolder}/${guid}_${version}.xpi`;
 
-    await addToCache("reviewUrls", [addonGUID], json.review_url);
+    await addToCache("reviewUrls", [guid], json.review_url);
 
     await downloadAddon(addonFileId, compressedFilePath);
-    await extractAddon(
-      compressedFilePath,
-      `${workspaceFolder}/${addonGUID}`,
-      `${workspaceFolder}/${addonGUID}/${addonVersion}`
-    );
+
+    try {
+      await extractAddon(
+        compressedFilePath,
+        `${workspaceFolder}/${guid}`,
+        `${workspaceFolder}/${guid}/${version}`
+      );
+    } catch (e) {
+      return { workspaceFolder, guid, version };
+    }
+    return { workspaceFolder, guid, version };
   } catch (error) {
     console.error(error);
   }

--- a/test/suite/commands/openFromUrl.test.ts
+++ b/test/suite/commands/openFromUrl.test.ts
@@ -29,9 +29,13 @@ describe("openFromUrl.ts", async () => {
     });
 
     it("should fail the stat check and call downloadAndExtract() if the manifest does not exist", async () => {
+      const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
+      executeCommandStub.resolves();
+
       const uri = {
         path: "/review/test-guid/test-version",
       };
+      
       const getRootFolderPathStub = sinon.stub(
         reviewRootDir,
         "getRootFolderPath"
@@ -53,12 +57,6 @@ describe("openFromUrl.ts", async () => {
       );
       showTextDocumentStub.resolves();
 
-      const updateWorkspaceFoldersStub = sinon.stub(
-        vscode.workspace,
-        "updateWorkspaceFolders"
-      );
-      updateWorkspaceFoldersStub.resolves();
-
       const context = {
         globalState: {
           update: sinon.stub(),
@@ -75,6 +73,9 @@ describe("openFromUrl.ts", async () => {
     });
 
     it("should not fail the stat check and not call downloadAndExtract()", async () => {
+      const executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
+      executeCommandStub.resolves();
+
       const uri = {
         path: "/review/test-guid/test-version",
       };
@@ -98,12 +99,6 @@ describe("openFromUrl.ts", async () => {
       );
       showTextDocumentStub.resolves();
 
-      const updateWorkspaceFoldersStub = sinon.stub(
-        vscode.workspace,
-        "updateWorkspaceFolders"
-      );
-      updateWorkspaceFoldersStub.resolves();
-
       const context = {
         globalState: {
           update: sinon.stub(),
@@ -122,13 +117,24 @@ describe("openFromUrl.ts", async () => {
 
   describe("openWorkspace()", async () => {
     it("should open the manifest if the workspace is already open", async () => {
-      const manifestUri = vscode.Uri.parse("test-manifest-uri");
+      
+      const context = {
+        globalState: {
+          update: sinon.stub(),
+        },
+      };
+      const getExtensionContextStub = sinon.stub(
+        globals,
+        "getExtensionContext"
+      );
+      getExtensionContextStub.returns(context as any);
       const executeCommandStub = sinon.stub(
         vscode.commands,
         "executeCommand"
       );
       executeCommandStub.resolves();
 
+      const manifestUri = vscode.Uri.parse("test-manifest-uri");
       const rootUri = vscode.Uri.parse("test-root-uri");
       const getRootFolderPathStub = sinon.stub(
         reviewRootDir,
@@ -150,8 +156,7 @@ describe("openFromUrl.ts", async () => {
       showTextDocumentStub.resolves();
 
       await openWorkspace(manifestUri.fsPath);
-      expect(executeCommandStub.called).to.be.true;
-      expect(showTextDocumentStub.called).to.be.true;
+      expect(executeCommandStub.calledOnceWith("vscode.openFolder")).to.be.true;
     });
   });
 });

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -39,33 +39,27 @@ describe("extension.ts", () => {
     sinon.restore();
   });
 
-  it("should activate and register commands and have 3 subscriptions", async () => {
-    const context = makeContext();
-    await activate(context);
-    const commands = await vscode.commands.getCommands(true);
-    expect(commands).to.include.members(["assay.get"]);
-    expect(commands).to.include.members(["assay.welcome"]);
-    expect(commands).to.include.members(["assay.review"]);
-    expect(context.subscriptions.length).to.be.greaterThan(10);    
-  });
-
   it("should deactivate and return undefined", async () => {
     // placeholder due to blank deactivate function
     const result = deactivate();
     expect(result).to.be.undefined;
   });
 
-  it("should load the manifest if launched with the intention to do so", async () => {
+  it("should activate and register commands and load the manifest if launched with the intention to do so", async () => {
     const context = makeContext();
     context.globalState.get = sinon.stub().returns("test");
     context.globalState.update = sinon.stub();
-    const openWorkspaceStub = sinon.stub(openFromUrl, "openWorkspace");
-    openWorkspaceStub.resolves();
+    const showTextDocumentStub = sinon.stub(vscode.window, "showTextDocument");
+    showTextDocumentStub.resolves();
 
     sinon.stub(vscode.window, "registerUriHandler");
     sinon.stub(vscode.commands, "registerCommand");
     await activate(context);
-    expect(openWorkspaceStub.calledOnce).to.be.true;
-    expect(openWorkspaceStub.calledWith("test")).to.be.true;
+    expect(showTextDocumentStub.calledOnce).to.be.true;
+    const commands = await vscode.commands.getCommands(true);
+    expect(commands).to.include.members(["assay.get"]);
+    expect(commands).to.include.members(["assay.welcome"]);
+    expect(commands).to.include.members(["assay.review"]);
+    expect(context.subscriptions.length).to.be.greaterThan(10);    
   });
 });


### PR DESCRIPTION
Fixes #36.

**Changes**
- Whenever ‘Review New Addon Version’ in VS Code or ‘Open in VS Code’ is used, the VS Code window now opens to the add-on version directory directly and defaults to its associated manifest.json.
- Instead of creating a new workspace or stacking on top of the existing one every time a new version is opened (which prompts the user to save the workspace every time they want to exit), the directory is opened directly in the explorer via vscode.openFolder.
- The commenting/review system is only launched if the user is inside the root folder. That way, Assay does not get in the way of the user’s other VS Code projects. Only the Assay commands menu launches (from where the user can still download by URL, enter their API key/secret, etc.)


`onStartupFinished`activation event needed to be added in order to facilitate opening manifest.json upon opening a new folder in VS Code. This causes issues with one of the tests where the extensionContext was already launched, causing the activation to fail. Merging the tests together to use one Context circumvents this (as the error is unrelated to what its testing for), but may not be ideal.
