### PR TITLE
Added Support for AMO's Review Page URL When Opening an Add-on for Review

### DIFF
--- a/src/commands/getAddon.ts
+++ b/src/commands/getAddon.ts
@@ -10,7 +10,7 @@ import { getRootFolderPath } from "../utils/reviewRootDir";
 
 export async function getInput(): Promise<string> {
   const input = await vscode.window.showInputBox({
-    prompt: "Enter Addon Slug, GUID, or URL",
+    prompt: "Enter Addon Slug, GUID, AMO ID, or URL",
     title: "Assay",
     ignoreFocusOut: true,
   });

--- a/src/utils/addonInfo.ts
+++ b/src/utils/addonInfo.ts
@@ -1,15 +1,15 @@
 import fetch from "node-fetch";
 
+import getAddonSlug from "./getAddonSlug";
 import { showErrorMessage } from "./processErrors";
 import { makeAuthHeader } from "./requestAuth";
 import constants from "../config/config";
 import { addonInfoResponse, errorMessages } from "../types";
 
 export async function getAddonInfo(input: string): Promise<addonInfoResponse> {
-  const slug: string = input.includes("/")
-    ? input.split("addon/")[1].split("/")[0]
-    : input;
+  const slug: string = getAddonSlug(input);
   const url = `${constants.apiBaseURL}addons/addon/${slug}`;
+
   const headers = await makeAuthHeader();
 
   const response = await fetch(url, { headers: headers });

--- a/src/utils/addonVersions.ts
+++ b/src/utils/addonVersions.ts
@@ -1,15 +1,15 @@
 import fetch from "node-fetch";
 import * as vscode from "vscode";
 
+import getAddonSlug from "./getAddonSlug";
 import { showErrorMessage } from "./processErrors";
 import { makeAuthHeader } from "./requestAuth";
 import constants from "../config/config";
 import { addonVersion, errorMessages } from "../types";
 
 export async function getAddonVersions(input: string, next?: string) {
-  const slug: string = input.includes("/")
-    ? input.split("addon/")[1].split("/")[0]
-    : input;
+  const slug: string = getAddonSlug(input);
+
   const url = next
     ? next
     : `${constants.apiBaseURL}addons/addon/${slug}/versions?filter=all_with_deleted`;

--- a/src/utils/getAddonSlug.ts
+++ b/src/utils/getAddonSlug.ts
@@ -5,5 +5,5 @@ export default function getAddonSlug(input: string) {
     ? "review-unlisted/"
     : "addon/";
 
-  return input.includes("/") ? input.split(delimiter)[1].split("/")[0] : input;
+  return input.includes("/") ? input.split(delimiter)[1]?.split("/")[0] : input;
 }

--- a/src/utils/getAddonSlug.ts
+++ b/src/utils/getAddonSlug.ts
@@ -1,11 +1,9 @@
 export default function getAddonSlug(input: string) {
-  let delimiter = "addon/";
-  if (input.includes("review/")) {
-    delimiter = "review/";
-  }
-  if (input.includes("review-unlisted/")) {
-    delimiter = "review-unlisted/";
-  }
+  const delimiter = input.includes("review/")
+    ? "review/"
+    : input.includes("review-unlisted/")
+    ? "review-unlisted/"
+    : "addon/";
 
   return input.includes("/") ? input.split(delimiter)[1].split("/")[0] : input;
 }

--- a/src/utils/getAddonSlug.ts
+++ b/src/utils/getAddonSlug.ts
@@ -1,0 +1,11 @@
+export default function getAddonSlug(input: string) {
+  let delimiter = "addon/";
+  if (input.includes("review/")) {
+    delimiter = "review/";
+  }
+  if (input.includes("review-unlisted/")) {
+    delimiter = "review-unlisted/";
+  }
+
+  return input.includes("/") ? input.split(delimiter)[1].split("/")[0] : input;
+}

--- a/src/utils/getAddonSlug.ts
+++ b/src/utils/getAddonSlug.ts
@@ -1,3 +1,16 @@
+/**
+ * Extracts an add-on's slug from a URL or other user input. If a slug cannot be
+ * identified, return the input string.
+ *
+ * The addon's slug is assumed to be the string between a well-known delimiter
+ * and an optional slash after the delimiter. For example, in input string of
+ * "...addon/ublock-origin/?utm_source..." would return "ublock-origin".
+ *
+ * Well-known URL delimiters are:
+ * - "addon/" - A normal AMO link.
+ * - "review/" - A listed add-on in the AMO reviewer tools.
+ * - "review-unlisted/" - A unlisted listed add-on in the AMO reviewer tools.
+ */
 export default function getAddonSlug(input: string) {
   const delimiter = input.includes("review/")
     ? "review/"

--- a/src/utils/getAddonSlug.ts
+++ b/src/utils/getAddonSlug.ts
@@ -12,11 +12,12 @@
  * - "review-unlisted/" - A unlisted listed add-on in the AMO reviewer tools.
  */
 export default function getAddonSlug(input: string) {
-  const delimiter = input.includes("review/")
-    ? "review/"
-    : input.includes("review-unlisted/")
-    ? "review-unlisted/"
-    : "addon/";
+  let delimiter = "addon/";
+  if (input.includes("review/")) {
+    delimiter = "review/";
+  } else if (input.includes("review-unlisted/")) {
+    delimiter = "review-unlisted/";
+  }
 
   return input.includes("/") ? input.split(delimiter)[1]?.split("/")[0] : input;
 }

--- a/test/suite/utils/getAddonSlug.test.ts
+++ b/test/suite/utils/getAddonSlug.test.ts
@@ -10,40 +10,47 @@ describe("getAddonSlug.ts", async () => {
   });
 
   describe("getAddonSlug()", () => {
-    it("should correctly return the AMO ID from a review url", async () => {
+    it("should correctly return the AMO ID from a review url.", async () => {
         const url = "https://reviewers.addons.mozilla.org/en-US/reviewers/review/128";
         const result = getAddonSlug(url);
         expect(result).to.equal("128");
     });
 
-    it("should correctly return the AMO ID from a review url with nonsense afterward", async () => {
+    it("should correctly return the AMO ID from a review url with nonsense afterward.", async () => {
         const url = "https://reviewers.addons.mozilla.org/en-US/reviewers/review/128/alot/of/nonsense";
         const result = getAddonSlug(url);
         expect(result).to.equal("128");
     });
 
-    it("should correctly return the AMO ID from an unlisted review url", async () => {
+    it("should correctly return the AMO ID from an unlisted review url.", async () => {
         const url = "https://reviewers.addons.mozilla.org/en-US/reviewers/review-unlisted/256";
         const result = getAddonSlug(url);
         expect(result).to.equal("256");
     });
 
-    it("should correctly return the AMO ID from an unlisted review url with nonsense afterward", async () => {
+    it("should correctly return the AMO ID from an unlisted review url with nonsense afterward.", async () => {
         const url = "https://reviewers.addons.mozilla.org/en-US/reviewers/review-unlisted/256/alot/of/nonsense";
         const result = getAddonSlug(url);
         expect(result).to.equal("256");
     });
 
-    it("should correctly return the slug from a addons url", async () => {
+    it("should correctly return the slug from a addons url.", async () => {
         const url = "https://addons.mozilla.org/en-US/firefox/addon/adblock-plus";
         const result = getAddonSlug(url);
         expect(result).to.equal("adblock-plus");
     });
 
-    it("should correctly return the slug from a addons url with nonsense afterward", async () => {
+    it("should correctly return the slug from a addons url with nonsense afterward.", async () => {
         const url = "https://addons.mozilla.org/en-US/firefox/addon/adblock-plus/alot/of/nonsense";
         const result = getAddonSlug(url);
         expect(result).to.equal("adblock-plus");
     });
+
+    it("should just return the input if no delimiter is identified, regardless of whether it really is a slug or not.", () => {
+      const url = "nonsense-or-slug";
+      const result = getAddonSlug(url);
+      expect(result).to.equal("nonsense-or-slug");
+    });
+
   });
 });

--- a/test/suite/utils/getAddonSlug.ts
+++ b/test/suite/utils/getAddonSlug.ts
@@ -1,0 +1,49 @@
+import { expect } from "chai";
+import { describe, it, afterEach } from "mocha";
+import * as sinon from "sinon";
+
+import getAddonSlug from "../../../src/utils/getAddonSlug";
+
+describe("getAddonSlug.ts", async () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("getAddonSlug()", () => {
+    it("should correctly return the AMO ID from a review url", async () => {
+        const url = "https://reviewers.addons.mozilla.org/en-US/reviewers/review/128";
+        const result = getAddonSlug(url);
+        expect(result).to.equal("128");
+    });
+
+    it("should correctly return the AMO ID from a review url with nonsense afterward", async () => {
+        const url = "https://reviewers.addons.mozilla.org/en-US/reviewers/review/128/alot/of/nonsense";
+        const result = getAddonSlug(url);
+        expect(result).to.equal("128");
+    });
+
+    it("should correctly return the AMO ID from an unlisted review url", async () => {
+        const url = "https://reviewers.addons.mozilla.org/en-US/reviewers/review-unlisted/256";
+        const result = getAddonSlug(url);
+        expect(result).to.equal("256");
+    });
+
+    it("should correctly return the AMO ID from an unlisted review url with nonsense afterward", async () => {
+        const url = "https://reviewers.addons.mozilla.org/en-US/reviewers/review-unlisted/256/alot/of/nonsense";
+        const result = getAddonSlug(url);
+        expect(result).to.equal("256");
+    });
+
+    it("should correctly return the slug from a addons url", async () => {
+        const url = "https://addons.mozilla.org/en-US/firefox/addon/adblock-plus";
+        const result = getAddonSlug(url);
+        expect(result).to.equal("adblock-plus");
+    });
+
+    it("should correctly return the slug from a addons url with nonsense afterward", async () => {
+        const url = "https://addons.mozilla.org/en-US/firefox/addon/adblock-plus/alot/of/nonsense";
+        const result = getAddonSlug(url);
+        expect(result).to.equal("adblock-plus");
+    });
+  });
+});


### PR DESCRIPTION
Closes #34

**Changes**
- The API already takes the internal AMO ID, so it was just a matter of modifying the delimiter based on URL.