### PR TITLE
Readonly Addons Folder, addons-linter via API

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
       "properties": {
         "assay.rootFolder": {
           "type": "string",
+          "description": "The directory where add-ons are saved. Using the 'Files: Readonly Include' setting, Assay will set the new directory to readonly and release the original.",
           "default": ""
         },
         "assay.diffTool": {

--- a/src/commands/getAddon.ts
+++ b/src/commands/getAddon.ts
@@ -27,20 +27,24 @@ export async function downloadAndExtract(
 ) {
   try {
     const input = urlGuid || (await getInput());
-
     const json: addonInfoResponse = await getAddonInfo(input);
 
     const versionInfo = await getVersionChoice(input, urlVersion);
-    const addonFileId = versionInfo.fileID;
+    const addonFileID = versionInfo.fileID;
     const version = versionInfo.version;
     const guid = json.guid;
+    const addonID = json.id;
 
     const workspaceFolder = await getRootFolderPath();
     const compressedFilePath = `${workspaceFolder}/${guid}_${version}.xpi`;
 
-    await addToCache("reviewUrls", [guid], json.review_url);
+    await addToCache("reviewMeta", [guid], {
+      review_url: json.review_url,
+      file_id: addonFileID,
+      id: addonID,
+    });
 
-    await downloadAddon(addonFileId, compressedFilePath);
+    await downloadAddon(addonFileID, compressedFilePath);
 
     await extractAddon(
       compressedFilePath,

--- a/src/commands/getAddon.ts
+++ b/src/commands/getAddon.ts
@@ -38,7 +38,8 @@ export async function downloadAndExtract(
     const workspaceFolder = await getRootFolderPath();
     const compressedFilePath = `${workspaceFolder}/${guid}_${version}.xpi`;
 
-    const existingVersions = await getFromCache("addonMeta", [guid, "file_ids"]) || {};
+    const existingVersions =
+      (await getFromCache("addonMeta", [guid, "file_ids"])) || {};
 
     existingVersions[version] = addonFileID;
 

--- a/src/commands/getAddon.ts
+++ b/src/commands/getAddon.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 import { addonInfoResponse } from "../types";
-import { addToCache } from "../utils/addonCache";
+import { addToCache, getFromCache } from "../utils/addonCache";
 import { downloadAddon } from "../utils/addonDownload";
 import { extractAddon } from "../utils/addonExtract";
 import { getAddonInfo } from "../utils/addonInfo";
@@ -38,9 +38,13 @@ export async function downloadAndExtract(
     const workspaceFolder = await getRootFolderPath();
     const compressedFilePath = `${workspaceFolder}/${guid}_${version}.xpi`;
 
+    const existingVersions = await getFromCache("addonMeta", [guid, "file_ids"]) || {};
+
+    existingVersions[version] = addonFileID;
+
     await addToCache("addonMeta", [guid], {
       review_url: json.review_url,
-      file_id: addonFileID,
+      file_ids: existingVersions,
       id: addonID,
     });
 

--- a/src/commands/getAddon.ts
+++ b/src/commands/getAddon.ts
@@ -38,7 +38,7 @@ export async function downloadAndExtract(
     const workspaceFolder = await getRootFolderPath();
     const compressedFilePath = `${workspaceFolder}/${guid}_${version}.xpi`;
 
-    await addToCache("reviewMeta", [guid], {
+    await addToCache("addonMeta", [guid], {
       review_url: json.review_url,
       file_id: addonFileID,
       id: addonID,

--- a/src/commands/lintAddon.ts
+++ b/src/commands/lintAddon.ts
@@ -49,7 +49,7 @@ async function formatNotice(versionPath: string, n: Message) {
 }
 
 async function fetchLints(guid: string) {
-  const { id: addonID, file_id: fileID } = await getFromCache("reviewMeta", [
+  const { id: addonID, file_id: fileID } = await getFromCache("addonMeta", [
     guid,
   ]);
   const url = `${constants.apiBaseURL}reviewers/addon/${addonID}/file/${fileID}/validation/`;

--- a/src/commands/lintAddon.ts
+++ b/src/commands/lintAddon.ts
@@ -1,0 +1,121 @@
+import * as vscode from "vscode";
+
+import constants from "../config/config";
+import { getDiagnosticCollection } from "../config/globals";
+import { Message, MessageType, errorMessages } from "../types";
+import { getFromCache } from "../utils/addonCache";
+import { showErrorMessage } from "../utils/processErrors";
+import { makeAuthHeader } from "../utils/requestAuth";
+import { splitUri } from "../utils/splitUri";
+
+function getUriFromVersionPath(versionPath: string, filepath: string) {
+  return vscode.Uri.file(`${versionPath}/${filepath}`);
+}
+
+async function formatNotice(versionPath: string, n: Message) {
+  const typeToSeverity = (type: MessageType) => {
+    switch (type) {
+      case "error":
+        return vscode.DiagnosticSeverity.Error;
+      case "notice":
+        return vscode.DiagnosticSeverity.Information;
+      case "warning":
+        return vscode.DiagnosticSeverity.Warning;
+    }
+  };
+
+  const fileUri = getUriFromVersionPath(versionPath, n.file);
+  const buffer =
+    (await vscode.workspace.fs.readFile(fileUri)) || new Uint8Array();
+  const fileText = buffer?.toString()?.split("\n");
+  const lineNumber = n.line ? n.line - 1 : 0;
+  const lineText = fileText?.at(lineNumber);
+
+  const startChar = n.line ? lineText?.match(/\S/)?.index : 0;
+  const endChar = n.line ? lineText?.length : 0;
+  const startPosition = new vscode.Position(lineNumber, startChar ?? 0);
+  const endPosition = new vscode.Position(lineNumber, endChar ?? 0);
+  const range = new vscode.Range(startPosition, endPosition);
+
+  const diagnostic: vscode.Diagnostic = {
+    range,
+    severity: typeToSeverity(n.type),
+    message: n.message,
+    source: "Assay",
+    code: n.code,
+  };
+
+  return diagnostic;
+}
+
+async function fetchLints(guid: string) {
+  const { id: addonID, file_id: fileID } = await getFromCache("reviewMeta", [
+    guid,
+  ]);
+  const url = `${constants.apiBaseURL}reviewers/addon/${addonID}/file/${fileID}/validation/`;
+
+  const headers = await makeAuthHeader();
+  const response = await fetch(url, { headers });
+
+  if (!response.ok) {
+    const errorMessages: errorMessages = {
+      window: {
+        404: `(Status ${response.status}): Failed to lint. Validation not found.`,
+        401: `(Status ${response.status}): Failed to lint. Unauthorized request.`,
+        403: `(Status ${response.status}): Failed to lint. Inadequate permissions`,
+        other: `(Status ${response.status}): Could not fetch lint.`,
+      },
+      thrown: {
+        404: "Failed to lint. Validation not found.",
+        401: "Failed to lint. Unauthorized request.",
+        403: "Failed to lint. Inadequate permissions",
+        other: "Could not fetch lint.",
+      },
+    };
+
+    return await showErrorMessage(errorMessages, response.status, fetchLints, [
+      guid,
+    ]);
+  }
+
+  const json = await response.json();
+
+  return json.validation;
+}
+
+export async function lintWorkspace() {
+  const workspace = vscode.workspace.workspaceFolders?.at(0);
+  if (!workspace) {
+    return;
+  }
+
+  const { versionPath, guid } = await splitUri(workspace.uri);
+  if (!versionPath) {
+    return;
+  }
+
+  const { success, messages } = await fetchLints(guid);
+  if (!success) {
+    return;
+  }
+
+  const populateDiagnostic = async (messages: Message[]) => {
+    for (const message of messages) {
+      const diagnostic = await formatNotice(versionPath, message);
+      if (diagnosticMap.has(message.file)) {
+        diagnosticMap.get(message.file)?.push(diagnostic);
+      } else {
+        diagnosticMap.set(message.file, [diagnostic]);
+      }
+    }
+  };
+
+  const diagnosticCollection = getDiagnosticCollection();
+  const diagnosticMap: Map<string, vscode.Diagnostic[]> = new Map();
+  await populateDiagnostic(messages);
+
+  diagnosticMap.forEach((diagnostics, file) => {
+    const uri = getUriFromVersionPath(versionPath, file);
+    diagnosticCollection.set(uri, diagnostics);
+  });
+}

--- a/src/commands/lintAddon.ts
+++ b/src/commands/lintAddon.ts
@@ -48,10 +48,16 @@ async function formatNotice(versionPath: string, n: Message) {
   return diagnostic;
 }
 
-async function fetchLints(guid: string) {
-  const { id: addonID, file_id: fileID } = await getFromCache("addonMeta", [
+async function fetchLints(guid: string, version: string) {
+  const { id: addonID, file_ids: fileIDs } = await getFromCache("addonMeta", [
     guid,
   ]);
+  const fileID = fileIDs[version];
+
+  if(!fileID || !addonID){
+    return;
+  }
+
   const url = `${constants.apiBaseURL}reviewers/addon/${addonID}/file/${fileID}/validation/`;
 
   const headers = await makeAuthHeader();
@@ -89,12 +95,12 @@ export async function lintWorkspace() {
     return;
   }
 
-  const { versionPath, guid } = await splitUri(workspace.uri);
+  const { versionPath, guid, version } = await splitUri(workspace.uri);
   if (!versionPath) {
     return;
   }
 
-  const { success, messages } = (await fetchLints(guid)) || [
+  const { success, messages } = (await fetchLints(guid, version)) || [
     undefined,
     undefined,
   ];

--- a/src/commands/lintAddon.ts
+++ b/src/commands/lintAddon.ts
@@ -54,7 +54,7 @@ async function fetchLints(guid: string, version: string) {
   ]);
   const fileID = fileIDs[version];
 
-  if(!fileID || !addonID){
+  if (!fileID || !addonID) {
     return;
   }
 

--- a/src/commands/setReadOnlyEditor.ts
+++ b/src/commands/setReadOnlyEditor.ts
@@ -1,5 +1,7 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
-export function setReadOnlyEditor(){
-    vscode.commands.executeCommand('workbench.action.files.setActiveEditorReadonlyInSession');
+export function setReadOnlyEditor() {
+  vscode.commands.executeCommand(
+    "workbench.action.files.setActiveEditorReadonlyInSession"
+  );
 }

--- a/src/commands/setReadOnlyEditor.ts
+++ b/src/commands/setReadOnlyEditor.ts
@@ -1,0 +1,5 @@
+import * as vscode from 'vscode';
+
+export function setReadOnlyEditor(){
+    vscode.commands.executeCommand('workbench.action.files.setActiveEditorReadonlyInSession');
+}

--- a/src/commands/setReadOnlyEditor.ts
+++ b/src/commands/setReadOnlyEditor.ts
@@ -1,7 +1,0 @@
-import * as vscode from "vscode";
-
-export function setReadOnlyEditor() {
-  vscode.commands.executeCommand(
-    "workbench.action.files.setActiveEditorReadonlyInSession"
-  );
-}

--- a/src/commands/updateTaskbar.ts
+++ b/src/commands/updateTaskbar.ts
@@ -32,7 +32,7 @@ export async function updateTaskbar() {
     throw new Error("No guid found");
   }
 
-  const reviewUrl = await getFromCache("reviewMeta", [guid, "review_url"]);
+  const reviewUrl = await getFromCache("addonMeta", [guid, "review_url"]);
 
   statusBarItem.text = `${guid} - Review Page`;
   statusBarItem.tooltip = reviewUrl;

--- a/src/commands/updateTaskbar.ts
+++ b/src/commands/updateTaskbar.ts
@@ -32,7 +32,7 @@ export async function updateTaskbar() {
     throw new Error("No guid found");
   }
 
-  const reviewUrl = await getFromCache("reviewUrls", ["guid"]);
+  const reviewUrl = await getFromCache("reviewMeta", ["guid", "review_url"]);
 
   statusBarItem.text = `${guid} - Review Page`;
   statusBarItem.tooltip = reviewUrl;

--- a/src/commands/updateTaskbar.ts
+++ b/src/commands/updateTaskbar.ts
@@ -3,6 +3,7 @@ import * as vscode from "vscode";
 
 import { getFromCache } from "../utils/addonCache";
 import { getRootFolderPath } from "../utils/reviewRootDir";
+import { splitUri } from "../utils/splitUri";
 
 export const statusBarItem = vscode.window.createStatusBarItem(
   vscode.StatusBarAlignment.Left,
@@ -11,28 +12,26 @@ export const statusBarItem = vscode.window.createStatusBarItem(
 statusBarItem.text = "Assay";
 
 export async function updateTaskbar() {
-  const activeEditor = vscode.window.activeTextEditor;
-  if (!activeEditor) {
+  const workspace = vscode.workspace.workspaceFolders;
+  if (!workspace) {
     return;
   }
 
-  const doc = activeEditor.document;
-  const filePath = doc.uri.fsPath;
-  const rootFolder = await getRootFolderPath();
-  if (!filePath.startsWith(rootFolder)) {
+  const filePath = workspace[0].uri;
+  const { guid, rootFolder } = await splitUri(filePath);
+  if (!filePath.fsPath.startsWith(rootFolder)) {
     statusBarItem.hide();
     throw new Error("File is not in the root folder");
   }
-
-  const relativePath = filePath.replace(rootFolder, "");
-  const guid = relativePath.split(path.sep)[1];
 
   if (!guid) {
     statusBarItem.hide();
     throw new Error("No guid found");
   }
 
-  const reviewUrl = await getFromCache("reviewMeta", ["guid", "review_url"]);
+  const reviewUrl = await getFromCache("reviewMeta", [guid, "review_url"]);
+
+  console.log(reviewUrl);
 
   statusBarItem.text = `${guid} - Review Page`;
   statusBarItem.tooltip = reviewUrl;

--- a/src/config/comment.ts
+++ b/src/config/comment.ts
@@ -1,22 +1,8 @@
 import * as vscode from "vscode";
 
+import { contextValues } from "../types";
+
 let commentId = 0;
-
-export type contextValues = "markForReview" | "comment";
-export interface CommentsCache {
-  [guid: string]: {
-    [version: string]: {
-      [filepath: string]: {
-        [lineNumber: string]: {
-          uri: vscode.Uri;
-          body: string;
-          contextValue: contextValues;
-        };
-      };
-    };
-  };
-}
-
 export class AssayThread implements vscode.CommentThread {
   canReply: boolean;
   constructor(

--- a/src/config/globals.ts
+++ b/src/config/globals.ts
@@ -1,4 +1,4 @@
-import { SecretStorage, ExtensionContext } from "vscode";
+import { SecretStorage, ExtensionContext, DiagnosticCollection } from "vscode";
 
 import { CustomFileDecorationProvider } from "../views/fileDecorations";
 
@@ -6,6 +6,7 @@ let secrets: SecretStorage;
 let storagePath: string;
 let fileDecorator: CustomFileDecorationProvider;
 let extensionContext: ExtensionContext;
+let diagnosticCollection: DiagnosticCollection;
 
 export function setExtensionSecretStorage(secretStorage: SecretStorage) {
   secrets = secretStorage;
@@ -37,4 +38,11 @@ export function setFileDecorator(decorator: CustomFileDecorationProvider) {
 
 export function getFileDecorator() {
   return fileDecorator;
+}
+
+export function setDiagnosticCollection(collection: DiagnosticCollection) {
+  diagnosticCollection = collection;
+}
+export function getDiagnosticCollection() {
+  return diagnosticCollection;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import {
 } from "./commands/getApiCreds";
 import { openInDiffTool } from "./commands/launchDiff";
 import { getAddonByUrl, handleUri } from "./commands/openFromUrl";
+import { setReadOnlyEditor } from "./commands/setReadOnlyEditor";
 import { updateAssay } from "./commands/updateAssay";
 import { updateTaskbar } from "./commands/updateTaskbar";
 import {
@@ -120,6 +121,8 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   );
 
+  const setReadOnlyEditorDisposable = vscode.window.onDidChangeActiveTextEditor(setReadOnlyEditor);
+
   context.subscriptions.push(
     UriHandlerDisposable,
     reviewDisposable,
@@ -138,7 +141,8 @@ export async function activate(context: vscode.ExtensionContext) {
     ),
     exportCommentsFileDisposable,
     vscode.window.registerFileDecorationProvider(fileDecorator),
-    assayUpdaterDisposable
+    assayUpdaterDisposable,
+    setReadOnlyEditorDisposable
   );
 
   // Comment API

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,6 @@ import {
 } from "./commands/getApiCreds";
 import { openInDiffTool } from "./commands/launchDiff";
 import { getAddonByUrl, handleUri } from "./commands/openFromUrl";
-import { setReadOnlyEditor } from "./commands/setReadOnlyEditor";
 import { updateAssay } from "./commands/updateAssay";
 import { updateTaskbar } from "./commands/updateTaskbar";
 import {
@@ -21,6 +20,10 @@ import {
 import { CommentManager } from "./utils/commentManager";
 import { loadFileDecorator } from "./utils/loadFileDecorator";
 import revealFile from "./utils/revealFile";
+import {
+  handleRootConfigurationChange,
+  setCachedRootFolder,
+} from "./utils/reviewRootDir";
 import { splitUri } from "./utils/splitUri";
 import { CustomFileDecorationProvider } from "./views/fileDecorations";
 import { AssayTreeDataProvider } from "./views/sidebarView";
@@ -121,7 +124,12 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  const setReadOnlyEditorDisposable = vscode.window.onDidChangeActiveTextEditor(setReadOnlyEditor);
+  // readonly setup
+  const config = vscode.workspace.getConfiguration("assay");
+  const rootFolder = config.get<string>("rootFolder");
+  setCachedRootFolder(rootFolder);
+  const handleRootConfigurationChangeDisposable =
+    vscode.workspace.onDidChangeConfiguration(handleRootConfigurationChange);
 
   context.subscriptions.push(
     UriHandlerDisposable,
@@ -142,7 +150,7 @@ export async function activate(context: vscode.ExtensionContext) {
     exportCommentsFileDisposable,
     vscode.window.registerFileDecorationProvider(fileDecorator),
     assayUpdaterDisposable,
-    setReadOnlyEditorDisposable
+    handleRootConfigurationChangeDisposable
   );
 
   // Comment API

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,13 +120,6 @@ export async function activate(context: vscode.ExtensionContext) {
     treeDataProvider: new AssayTreeDataProvider(),
   });
 
-  const exportCommentsFileDisposable = vscode.commands.registerCommand(
-    "assay.exportCommentsFromContext",
-    async () => {
-      await exportCommentsFromContext();
-    }
-  );
-
   // Configure watchers for the rootFolder.
   const config = vscode.workspace.getConfiguration("assay");
   const rootFolder = config.get<string>("rootFolder");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,10 +8,12 @@ import {
   testApiCredentials,
 } from "./commands/getApiCreds";
 import { openInDiffTool } from "./commands/launchDiff";
+import { lintWorkspace } from "./commands/lintAddon";
 import { getAddonByUrl, handleUri } from "./commands/openFromUrl";
 import { updateAssay } from "./commands/updateAssay";
 import { updateTaskbar } from "./commands/updateTaskbar";
 import {
+  setDiagnosticCollection,
   setExtensionContext,
   setExtensionSecretStorage,
   setExtensionStoragePath,
@@ -130,6 +132,12 @@ export async function activate(context: vscode.ExtensionContext) {
   setCachedRootFolder(rootFolder);
   const handleRootConfigurationChangeDisposable =
     vscode.workspace.onDidChangeConfiguration(handleRootConfigurationChange);
+
+  // linting setup
+  const diagnosticCollection =
+    vscode.languages.createDiagnosticCollection("addons-linter");
+  setDiagnosticCollection(diagnosticCollection);
+  lintWorkspace();
 
   context.subscriptions.push(
     UriHandlerDisposable,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,14 +126,14 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  // readonly setup
+  // Configure watchers for the rootFolder.
   const config = vscode.workspace.getConfiguration("assay");
   const rootFolder = config.get<string>("rootFolder");
   setCachedRootFolder(rootFolder);
   const handleRootConfigurationChangeDisposable =
     vscode.workspace.onDidChangeConfiguration(handleRootConfigurationChange);
 
-  // linting setup
+  // Execute linting.
   const diagnosticCollection =
     vscode.languages.createDiagnosticCollection("addons-linter");
   setDiagnosticCollection(diagnosticCollection);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { Uri } from "vscode";
+
 export type addonInfoResponse = {
   id: string;
   slug: string;
@@ -44,6 +46,33 @@ export type errorMessages = {
   };
 };
 
+export type contextValues = "markForReview" | "comment";
+
+export type CommentsCache = {
+  [guid: string]: {
+    [version: string]: {
+      [filepath: string]: {
+        [lineNumber: string]: {
+          uri: Uri;
+          body: string;
+          contextValue: contextValues;
+        };
+      };
+    };
+  };
+};
+
 export type filesReadonlyIncludeConfig = {
   [key: string]: boolean;
+};
+
+export type MessageType = "error" | "notice" | "warning";
+
+export type Message = {
+  type: MessageType;
+  code: string;
+  message: string;
+  description: string;
+  file: string;
+  line: number | undefined;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type addonInfoResponse = {
+  id: string;
   slug: string;
   name: {
     [key: string]: string;
@@ -41,4 +42,8 @@ export type errorMessages = {
   thrown: {
     [code: string]: string;
   };
+};
+
+export type filesReadonlyIncludeConfig = {
+  [key: string]: boolean;
 };

--- a/src/utils/addonExtract.ts
+++ b/src/utils/addonExtract.ts
@@ -17,7 +17,6 @@ export async function extractAddon(
   compressedFilePath: string,
   addonVersionFolderPath: string
 ) {
-  
   if (!(await dirExistsOrMake(addonVersionFolderPath))) {
     const choice = await vscode.window.showQuickPick(["Yes", "No"], {
       placeHolder: "Addon already exists. Overwrite?",

--- a/src/utils/addonExtract.ts
+++ b/src/utils/addonExtract.ts
@@ -10,14 +10,14 @@ export async function dirExistsOrMake(dir: string) {
     await fs.promises.mkdir(dir, { recursive: true });
     return true;
   }
+  return false;
 }
 
 export async function extractAddon(
   compressedFilePath: string,
   addonVersionFolderPath: string
 ) {
-  await dirExistsOrMake(addonVersionFolderPath);
-
+  
   if (!(await dirExistsOrMake(addonVersionFolderPath))) {
     const choice = await vscode.window.showQuickPick(["Yes", "No"], {
       placeHolder: "Addon already exists. Overwrite?",

--- a/src/utils/commentManager.ts
+++ b/src/utils/commentManager.ts
@@ -9,13 +9,8 @@ import {
 import { loadFileDecorator } from "./loadFileDecorator";
 import { splitUri } from "./splitUri";
 import { exportVersionComments } from "../commands/exportComments";
-import {
-  AssayComment,
-  AssayReply,
-  AssayThread,
-  CommentsCache,
-  contextValues,
-} from "../config/comment";
+import { AssayComment, AssayReply, AssayThread } from "../config/comment";
+import { CommentsCache, contextValues } from "../types";
 
 export class CommentManager {
   controller: vscode.CommentController;

--- a/src/utils/getThreadLocation.ts
+++ b/src/utils/getThreadLocation.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import { splitUri } from "./splitUri";
 import { AssayThread } from "../config/comment";
 
-async function readFile(uri: vscode.Uri) {
+export async function readFile(uri: vscode.Uri) {
   try {
     return await vscode.workspace.fs.readFile(uri);
   } catch {

--- a/src/utils/reviewRootDir.ts
+++ b/src/utils/reviewRootDir.ts
@@ -1,6 +1,31 @@
 import * as fs from "fs";
 import * as vscode from "vscode";
 
+import { filesReadonlyIncludeConfig } from "../types";
+
+let cachedRootFolder: string | undefined;
+
+export function setCachedRootFolder(filepath: string | undefined) {
+  cachedRootFolder = filepath;
+}
+
+export async function getRootFolderPath() {
+  const config = vscode.workspace.getConfiguration("assay");
+  const rootFolder = config.get<string>("rootFolder");
+
+  // check if the folder still exists. if it doesn't, prompt the user to select a new one
+  // TODO: very sudden. do a prompt before it first
+  if ((rootFolder && !fs.existsSync(rootFolder)) || !rootFolder) {
+    const newRootFolder = await selectRootFolder();
+    if (!newRootFolder) {
+      throw new Error("No root folder selected");
+    }
+    await storeRootFolderSetting(newRootFolder);
+    return newRootFolder;
+  }
+  return rootFolder;
+}
+
 export async function selectRootFolder() {
   const options: vscode.OpenDialogOptions = {
     canSelectFiles: false,
@@ -15,7 +40,7 @@ export async function selectRootFolder() {
   }
 }
 
-export async function storeRootFolderSetting(rootFolder: string) {
+async function storeRootFolderSetting(rootFolder: string) {
   const config = vscode.workspace.getConfiguration("assay");
   await config.update(
     "rootFolder",
@@ -24,18 +49,38 @@ export async function storeRootFolderSetting(rootFolder: string) {
   );
 }
 
-export async function getRootFolderPath() {
+// whenever rootFolder or readonlyInclude is modified, ensure that 1) the old root folder is removed from readonly, and 2) the new one is added.
+export async function handleRootConfigurationChange(
+  event: vscode.ConfigurationChangeEvent
+) {
+  if (
+    event.affectsConfiguration("assay.rootFolder") ||
+    event.affectsConfiguration("files.readonlyInclude")
+  ) {
+    await setRootToReadonly();
+  }
+}
+
+
+export async function setRootToReadonly() {
   const config = vscode.workspace.getConfiguration("assay");
   const rootFolder = config.get<string>("rootFolder");
 
-  // check if the folder still exists. if it doesn't, prompt the user to select a new one
-  if ((rootFolder && !fs.existsSync(rootFolder)) || !rootFolder) {
-    const newRootFolder = await selectRootFolder();
-    if (!newRootFolder) {
-      throw new Error("No root folder selected");
-    }
-    await storeRootFolderSetting(newRootFolder);
-    return newRootFolder;
+  const fileConfig = vscode.workspace.getConfiguration("files");
+  const readOnlyFiles = fileConfig.get("readonlyInclude") as filesReadonlyIncludeConfig;
+
+  // remove the cachedRootFolder's readonly property.
+  const globInitialFolder = `${cachedRootFolder}/**`;
+  if (globInitialFolder in readOnlyFiles) {
+    readOnlyFiles[globInitialFolder] = false;
   }
-  return rootFolder;
+
+  await fileConfig.update(
+    "readonlyInclude",
+    { ...readOnlyFiles, [`${rootFolder}/**`]: true },
+    vscode.ConfigurationTarget.Global
+  );
+
+  // update the cached root folder here and on launch
+  setCachedRootFolder(rootFolder);
 }

--- a/src/utils/reviewRootDir.ts
+++ b/src/utils/reviewRootDir.ts
@@ -61,13 +61,14 @@ export async function handleRootConfigurationChange(
   }
 }
 
-
 export async function setRootToReadonly() {
   const config = vscode.workspace.getConfiguration("assay");
   const rootFolder = config.get<string>("rootFolder");
 
   const fileConfig = vscode.workspace.getConfiguration("files");
-  const readOnlyFiles = fileConfig.get("readonlyInclude") as filesReadonlyIncludeConfig;
+  const readOnlyFiles = fileConfig.get(
+    "readonlyInclude"
+  ) as filesReadonlyIncludeConfig;
 
   // remove the cachedRootFolder's readonly property.
   const globInitialFolder = `${cachedRootFolder}/**`;

--- a/src/utils/reviewRootDir.ts
+++ b/src/utils/reviewRootDir.ts
@@ -61,7 +61,7 @@ export async function handleRootConfigurationChange(
   }
 }
 
-export async function setRootToReadonly() {
+async function setRootToReadonly() {
   const config = vscode.workspace.getConfiguration("assay");
   const rootFolder = config.get<string>("rootFolder");
 

--- a/src/utils/splitUri.ts
+++ b/src/utils/splitUri.ts
@@ -9,5 +9,14 @@ export async function splitUri(uri: Uri) {
   const guid = relativePath.split("/")[1];
   const version = relativePath.split("/")[2];
   const filepath = relativePath.split(version)[1];
-  return { rootFolder, fullPath, relativePath, guid, version, filepath };
+  const versionPath = version ? `${rootFolder}/${guid}/${version}` : undefined;
+  return {
+    rootFolder,
+    versionPath,
+    fullPath,
+    relativePath,
+    guid,
+    version,
+    filepath,
+  };
 }

--- a/test/suite/commands/getAddon.test.ts
+++ b/test/suite/commands/getAddon.test.ts
@@ -35,6 +35,7 @@ describe("getAddon.ts", async () => {
       // stub getAddonInfo
       const getAddonInfoStub = sinon.stub(addonInfo, "getAddonInfo");
       getAddonInfoStub.resolves({
+        id: "id",
         slug: "test-slug",
         name: {
           en_US: "Test Slug",

--- a/test/suite/commands/lintAddon.test.ts
+++ b/test/suite/commands/lintAddon.test.ts
@@ -1,0 +1,195 @@
+import { expect } from "chai";
+import { afterEach, describe, it } from "mocha";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+
+import { lintWorkspace } from "../../../src/commands/lintAddon";
+import * as globals from "../../../src/config/globals";
+import * as cacheFunctions from "../../../src/utils/addonCache";
+import * as getThreadLocation from "../../../src/utils/getThreadLocation";
+import * as processErrors from "../../../src/utils/processErrors";
+import * as authUtils from "../../../src/utils/requestAuth";
+import * as splitUri from "../../../src/utils/splitUri";
+
+describe("addonDownload.ts", async () => {
+
+  afterEach(async () => {
+    sinon.restore();
+  });
+
+  describe("lintWorkspace()", () => {
+    it("should correctly create a set Diagnostic[] from lint results and set it in the diagnosticCollection.", async () => {
+        
+        const readFileStub = sinon.stub(getThreadLocation, 'readFile');
+        readFileStub.resolves(new Uint8Array());
+
+        const workspaceFoldersStub = sinon.stub(vscode.workspace, "workspaceFolders");
+        workspaceFoldersStub.value([
+            {
+            uri: "rootUri",
+            },
+        ]);
+
+        const splitUriStub = sinon.stub(splitUri, "splitUri");
+        splitUriStub.resolves({
+            rootFolder: "",
+            versionPath: "version",
+            fullPath: "",
+            relativePath: "",
+            guid: "",
+            version: "",
+            filepath: ""
+        });
+
+        const getFromCacheStub = sinon.stub(cacheFunctions, "getFromCache");
+        getFromCacheStub.resolves({id: "id", file_id: "fileID"});
+
+        const authStub = sinon.stub(authUtils, "makeAuthHeader");
+        authStub.resolves({ Authorization: "test" });
+
+        const data = {
+            success: true,
+            messages: [{
+            type: "error",
+            code: "error code",
+            message: "error message",
+            description: "description",
+            file: "file1.js",
+            line: 1
+        },
+        {
+            type: "error",
+            code: "error code 2",
+            message: "error message 2",
+            description: "description 2",
+            file: "file1.js",
+            line: 1
+        },
+        {
+            type: "notice",
+            code: "notice code",
+            message: "notice message",
+            description: "description",
+            file: "file2.js",
+            line: 2
+        },
+        {
+            type: "warning",
+            code: "warning code",
+            message: "warning message",
+            description: "description",
+            file: "file3.js",
+            line: 3
+        }
+        ]};
+        const fetchStub = sinon.stub(global, "fetch");
+        fetchStub.resolves({
+            json: () => ({validation: data}),
+            ok: true
+        } as unknown as Response);
+
+        const collection = vscode.languages.createDiagnosticCollection("addons-linter");
+        const getDiagnosticCollectionStub = sinon.stub(globals, "getDiagnosticCollection");
+        getDiagnosticCollectionStub.returns(collection);
+
+        await lintWorkspace();
+
+        const errorUri = vscode.Uri.parse("version/file1.js");
+        expect(collection.has(errorUri)).to.be.equal(true);
+        expect(collection.get(errorUri)?.length).to.be.equal(2);
+        const errorDiagnostic = collection.get(errorUri)?.at(0);
+        const errorDiagnosticTwo = collection.get(errorUri)?.at(1);
+
+        const errorStart = new vscode.Position(0, 0);
+        const errorEnd = new vscode.Position(0, 0);
+        const errorRange = new vscode.Range(errorStart, errorEnd);
+
+        expect(errorDiagnostic?.range).to.deep.equal(errorRange);
+        expect(errorDiagnostic?.severity).to.be.equal(vscode.DiagnosticSeverity.Error);
+        expect(errorDiagnostic?.message).to.be.equal("error message");
+        expect(errorDiagnostic?.code).to.be.equal("error code");
+
+        expect(errorDiagnosticTwo?.range).to.deep.equal(errorRange);
+        expect(errorDiagnosticTwo?.severity).to.be.equal(vscode.DiagnosticSeverity.Error);
+        expect(errorDiagnosticTwo?.message).to.be.equal("error message 2");
+        expect(errorDiagnosticTwo?.code).to.be.equal("error code 2");
+
+        const noticeUri = vscode.Uri.parse("version/file2.js");
+        expect(collection.has(noticeUri)).to.be.equal(true);
+        expect(collection.get(noticeUri)?.length).to.be.equal(1);
+        const noticeDiagnostic = collection.get(noticeUri)?.at(0);
+
+        const noticeStart = new vscode.Position(1, 0);
+        const noticeEnd = new vscode.Position(1, 0);
+        const noticeRange = new vscode.Range(noticeStart, noticeEnd);
+
+        expect(noticeDiagnostic?.range).to.deep.equal(noticeRange);
+        expect(noticeDiagnostic?.severity).to.be.equal(vscode.DiagnosticSeverity.Information);
+        expect(noticeDiagnostic?.message).to.be.equal("notice message");
+        expect(noticeDiagnostic?.code).to.be.equal("notice code");
+
+        const warningUri = vscode.Uri.parse("version/file3.js");
+        expect(collection.has(warningUri)).to.be.equal(true);
+        expect(collection.get(warningUri)?.length).to.be.equal(1);
+        const warningDiagnostic = collection.get(warningUri)?.at(0);
+
+        const warningStart = new vscode.Position(2, 0);
+        const warningEnd = new vscode.Position(2, 0);
+        const warningRange = new vscode.Range(warningStart, warningEnd);
+
+        expect(warningDiagnostic?.range).to.deep.equal(warningRange);
+        expect(warningDiagnostic?.severity).to.be.equal(vscode.DiagnosticSeverity.Warning);
+        expect(warningDiagnostic?.message).to.be.equal("warning message");
+        expect(warningDiagnostic?.code).to.be.equal("warning code");
+
+
+      });
+
+    it("should show an error message when fetch fails with a 404", async () => {
+        const readFileStub = sinon.stub(getThreadLocation, 'readFile');
+        readFileStub.resolves(new Uint8Array());
+
+        const workspaceFoldersStub = sinon.stub(vscode.workspace, "workspaceFolders");
+        workspaceFoldersStub.value([
+            {
+            uri: "rootUri",
+            },
+        ]);
+
+        const splitUriStub = sinon.stub(splitUri, "splitUri");
+        splitUriStub.resolves({
+            rootFolder: "",
+            versionPath: "version",
+            fullPath: "",
+            relativePath: "",
+            guid: "",
+            version: "",
+            filepath: ""
+        });
+
+        const getFromCacheStub = sinon.stub(cacheFunctions, "getFromCache");
+        getFromCacheStub.resolves({id: "id", file_id: "fileID"});
+
+        const showErrorMessageStub = sinon.stub(processErrors, "showErrorMessage");
+
+        const authStub = sinon.stub(authUtils, "makeAuthHeader");
+        authStub.resolves({ Authorization: "test" });
+
+        const data = {
+            success: true,
+            messages: []};
+        const fetchStub = sinon.stub(global, "fetch");
+        fetchStub.resolves({
+            json: () => ({validation: data}),
+            ok: false,
+            status: 404
+        } as unknown as Response);
+
+        await lintWorkspace();
+        
+        expect(showErrorMessageStub.called).to.be.true;
+    });
+  });
+
+});
+

--- a/test/suite/commands/lintAddon.test.ts
+++ b/test/suite/commands/lintAddon.test.ts
@@ -37,12 +37,12 @@ describe("addonDownload.ts", async () => {
             fullPath: "",
             relativePath: "",
             guid: "",
-            version: "",
+            version: "version",
             filepath: ""
         });
 
         const getFromCacheStub = sinon.stub(cacheFunctions, "getFromCache");
-        getFromCacheStub.resolves({id: "id", file_id: "fileID"});
+        getFromCacheStub.resolves({id: "id", file_ids: {"version": "fileID"}});
 
         const authStub = sinon.stub(authUtils, "makeAuthHeader");
         authStub.resolves({ Authorization: "test" });
@@ -163,12 +163,12 @@ describe("addonDownload.ts", async () => {
             fullPath: "",
             relativePath: "",
             guid: "",
-            version: "",
+            version: "version",
             filepath: ""
         });
 
         const getFromCacheStub = sinon.stub(cacheFunctions, "getFromCache");
-        getFromCacheStub.resolves({id: "id", file_id: "fileID"});
+        getFromCacheStub.resolves({id: "id", file_ids: {"version": "fileID"}});
 
         const showErrorMessageStub = sinon.stub(processErrors, "showErrorMessage");
 

--- a/test/suite/utils/AddonExtract.test.ts
+++ b/test/suite/utils/AddonExtract.test.ts
@@ -166,7 +166,7 @@ describe("AddonExtract.ts", async () => {
 
       const res = await dirExistsOrMake(extractedworkspaceFolder);
       expect(fs.existsSync(extractedworkspaceFolder)).to.be.true;
-      expect(res).to.be.undefined;
+      expect(res).to.be.false;
     });
   });
 });

--- a/test/suite/utils/AddonInfo.test.ts
+++ b/test/suite/utils/AddonInfo.test.ts
@@ -13,6 +13,7 @@ const addonSlug = "test-addon";
 const addonId = "123456";
 const addonUrl = `https://addons.mozilla.org/en-US/firefox/addon/${addonSlug}`;
 const expected: addonInfoResponse = {
+  id: "id",
   slug: addonSlug,
   name: {
     en: "Test addon",

--- a/test/suite/utils/commentManager.test.ts
+++ b/test/suite/utils/commentManager.test.ts
@@ -5,8 +5,9 @@ import path = require("path");
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 
-import { AssayReply, AssayThread, contextValues } from "../../../src/config/comment";
+import { AssayReply, AssayThread } from "../../../src/config/comment";
 import { setExtensionStoragePath } from "../../../src/config/globals";
+import { contextValues } from "../../../src/types";
 import * as addonCache from "../../../src/utils/addonCache";
 import { CommentManager } from "../../../src/utils/commentManager";
 import * as getThreadLocation from "../../../src/utils/getThreadLocation";

--- a/test/suite/utils/getThreadLocation.test.ts
+++ b/test/suite/utils/getThreadLocation.test.ts
@@ -3,7 +3,8 @@ import { describe, it, afterEach, beforeEach } from "mocha";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 
-import { AssayThread, contextValues } from "../../../src/config/comment";
+import { AssayThread } from "../../../src/config/comment";
+import { contextValues } from "../../../src/types";
 import { getThreadLocation, rangeToString, rangeTruncation, stringToRange } from "../../../src/utils/getThreadLocation";
 import * as reviewRootDir from "../../../src/utils/reviewRootDir";
 


### PR DESCRIPTION
Closes #35 

**Changes**
- The root folder is set as readonly in VS Code using the settings property [`files.readonlyInclude`](https://code.visualstudio.com/updates/v1_79#_readonly-mode), making use of Glob patterns to do so.
- Whenever the root folder is changed in settings, the readonly property is removed from the initial root folder and added to the new one.
- Assay will forcibly set the root folder as readonly again if the user attempts to remove the root folder from `files.readonlyInclude`.

**Note 1**: This isn't the ideal way of going about it and is a bit hack-y, but the alternative `TextDocumentContentProvider` would introduce more problems (which handles individual files -- to have it working with the file explorer would mean listening for a text editor open, immediately closing that editor, and opening the readonly document instead -- which one can imagine could be an unpleasant user experience.)

**Note 2**: The readonly state prevents the user from deleting or modifying anything in the root folder within VS Code. However, as of now, there's no failsafe for when a user modifies the add-on code externally (ex. in a text editor). There's a lot of different options here (such as checking the 'last modified' state of add-ons), but the computational work to check every time may not be worth it. Best to discuss this over Zoom.

![image](https://github.com/mozilla/assay/assets/44586776/9961b571-77a8-4de8-8822-03ccbd3528cd)
![image](https://github.com/mozilla/assay/assets/44586776/21002236-12fa-4abe-ace1-a7a061064709)
- `reviewUrls.cache` -> `addonMeta.cache `to additionally store the xpi's file id under its version and addon id (as the validation endpoint does not take GUID nor version)
- Lints are fetched from the API endpoint [`/reviewers/addon/<addon_id>/file/<file_id>/validation/`](https://github.com/diox/olympia/blob/9eaed4d5924ec9e9ef180ef3579c38004269d392/docs/topics/api/reviewers.rst) on launch iff the user's workspace is opened to a version.

![image](https://github.com/mozilla/assay/assets/44586776/f9157b9d-46b1-4bd3-8f73-d1aa5d9de163)


Also of note is a [separate repository for a standalone addons-linter extension](https://github.com/chrstinalin/vscode-addons-linter), when/if we want to go down that route.