### PR TITLE
Replace QuickPick String Literals with String Enums

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ export type errorMessages = {
   };
 };
 
-export enum QuickPick {
+export enum QPOption {
   Save = "Save my Preference",
   Ask = "Ask Every Time",
   None = "No Preference",

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,10 +42,11 @@ export type errorMessages = {
     [code: string]: string;
   };
 };
-export enum ExportPreference {
+
+export enum QuickPick {
   Save = "Save my Preference",
   Ask = "Ask Every Time",
   None = "No Preference",
   Yes = "Yes",
-  No = "No"
+  No = "No",
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,3 +42,10 @@ export type errorMessages = {
     [code: string]: string;
   };
 };
+export enum ExportPreference {
+  Save = "Save my Preference",
+  Ask = "Ask Every Time",
+  None = "No Preference",
+  Yes = "Yes",
+  No = "No"
+}

--- a/src/utils/addonCache.ts
+++ b/src/utils/addonCache.ts
@@ -3,7 +3,6 @@ import * as path from "path";
 
 import { getExtensionStoragePath } from "../config/globals";
 
-
 /**
  * Adds a value to keys in cache cacheName.
  * If an empty string is passed to value, the value at key(s) is deleted from cache.

--- a/src/utils/addonExtract.ts
+++ b/src/utils/addonExtract.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as vscode from "vscode";
 
 import { showErrorMessage } from "./processErrors";
-import { errorMessages } from "../types";
+import { QuickPick, errorMessages } from "../types";
 
 export async function dirExistsOrMake(dir: string) {
   if (!fs.existsSync(dir)) {
@@ -20,10 +20,13 @@ export async function extractAddon(
   await dirExistsOrMake(addonFolderPath);
 
   if (!(await dirExistsOrMake(addonVersionFolderPath))) {
-    const choice = await vscode.window.showQuickPick(["Yes", "No"], {
-      placeHolder: "Addon already exists. Overwrite?",
-    });
-    if (choice === "No" || !choice) {
+    const choice = await vscode.window.showQuickPick(
+      [QuickPick.Yes, QuickPick.No],
+      {
+        placeHolder: "Addon already exists. Overwrite?",
+      }
+    );
+    if (choice === QuickPick.No || !choice) {
       await fs.promises.unlink(compressedFilePath);
       throw new Error("Extraction cancelled");
     }

--- a/src/utils/addonExtract.ts
+++ b/src/utils/addonExtract.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as vscode from "vscode";
 
 import { showErrorMessage } from "./processErrors";
-import { QuickPick, errorMessages } from "../types";
+import { QPOption, errorMessages } from "../types";
 
 export async function dirExistsOrMake(dir: string) {
   if (!fs.existsSync(dir)) {
@@ -21,12 +21,12 @@ export async function extractAddon(
 
   if (!(await dirExistsOrMake(addonVersionFolderPath))) {
     const choice = await vscode.window.showQuickPick(
-      [QuickPick.Yes, QuickPick.No],
+      [QPOption.Yes, QPOption.No],
       {
         placeHolder: "Addon already exists. Overwrite?",
       }
     );
-    if (choice === QuickPick.No || !choice) {
+    if (choice === QPOption.No || !choice) {
       await fs.promises.unlink(compressedFilePath);
       throw new Error("Extraction cancelled");
     }

--- a/src/utils/commentManager.ts
+++ b/src/utils/commentManager.ts
@@ -274,7 +274,7 @@ export class CommentManager {
 
   /**
    * Fetches comments and returns an iterator.
-   * @returns iterator function. 
+   * @returns iterator function.
    */
   private async getCachedCommentIterator() {
     const comments = await this.fetchCommentsFromCache();

--- a/src/utils/getDeleteCommentsPreference.ts
+++ b/src/utils/getDeleteCommentsPreference.ts
@@ -1,15 +1,15 @@
 import * as vscode from "vscode";
 
-import { QuickPick } from "../types";
+import { QPOption } from "../types";
 
 export default async function getDeleteCommentsPreference() {
   const config = vscode.workspace.getConfiguration("assay");
   const savedPreference =
-    (config.get<string>("deleteCommentsOnExport") as QuickPick) ||
-    QuickPick.None;
+    (config.get<string>("deleteCommentsOnExport") as QPOption) ||
+    QPOption.None;
 
-  if ([QuickPick.Yes, QuickPick.No].includes(savedPreference)) {
-    return savedPreference === QuickPick.Yes;
+  if ([QPOption.Yes, QPOption.No].includes(savedPreference)) {
+    return savedPreference === QPOption.Yes;
   } else {
     // No preference or ask every time.
     return await promptdeleteComments(config, savedPreference);
@@ -21,7 +21,7 @@ async function promptdeleteComments(
   savedPreference: string
 ) {
   const selectedPreference = await vscode.window.showQuickPick(
-    [QuickPick.Yes, QuickPick.No],
+    [QPOption.Yes, QPOption.No],
     {
       title: "Delete version comments after exporting?",
       ignoreFocusOut: true,
@@ -33,11 +33,11 @@ async function promptdeleteComments(
   }
 
   // Ask to save preference.
-  if (savedPreference === QuickPick.None) {
+  if (savedPreference === QPOption.None) {
     await setDeleteCommentsPreference(config, selectedPreference);
   }
 
-  return selectedPreference === QuickPick.Yes;
+  return selectedPreference === QPOption.Yes;
 }
 
 async function setDeleteCommentsPreference(
@@ -45,10 +45,10 @@ async function setDeleteCommentsPreference(
   selectedPreference: string
 ) {
   const input = await vscode.window.showQuickPick(
-    [QuickPick.Save, QuickPick.Ask],
+    [QPOption.Save, QPOption.Ask],
     {
       title:
-        selectedPreference === QuickPick.No
+        selectedPreference === QPOption.No
           ? "Delete comments on every export?"
           : "Keep comments on every export?",
       ignoreFocusOut: true,
@@ -61,7 +61,7 @@ async function setDeleteCommentsPreference(
 
   await config.update(
     "deleteCommentsOnExport",
-    input === QuickPick.Save ? selectedPreference : QuickPick.Ask,
+    input === QPOption.Save ? selectedPreference : QPOption.Ask,
     true
   );
 }

--- a/src/utils/getDeleteCommentsPreference.ts
+++ b/src/utils/getDeleteCommentsPreference.ts
@@ -1,12 +1,14 @@
 import * as vscode from "vscode";
 
+import { ExportPreference } from "../types";
+
 export default async function getDeleteCommentsPreference() {
   const config = vscode.workspace.getConfiguration("assay");
   const savedPreference =
-    config.get<string>("deleteCommentsOnExport") || "No Preference";
+    config.get<string>("deleteCommentsOnExport") as ExportPreference || ExportPreference.None;
 
-  if (["Yes", "No"].includes(savedPreference)) {
-    return savedPreference === "Yes";
+  if ([ExportPreference.Yes, ExportPreference.No].includes(savedPreference)) {
+    return savedPreference === ExportPreference.Yes;
   } else {
     // No preference or ask every time.
     return await promptdeleteComments(config, savedPreference);
@@ -17,7 +19,7 @@ async function promptdeleteComments(
   config: vscode.WorkspaceConfiguration,
   savedPreference: string
 ) {
-  const selectedPreference = await vscode.window.showQuickPick(["Yes", "No"], {
+  const selectedPreference = await vscode.window.showQuickPick([ExportPreference.Yes, ExportPreference.No], {
     title: "Delete version comments after exporting?",
     ignoreFocusOut: true,
   });
@@ -27,22 +29,22 @@ async function promptdeleteComments(
   }
 
   // Ask to save preference.
-  if (savedPreference === "No Preference") {
-    await setdeleteCommentsPreference(config, selectedPreference);
+  if (savedPreference ===  ExportPreference.None) {
+    await setDeleteCommentsPreference(config, selectedPreference);
   }
 
-  return selectedPreference === "Yes";
+  return selectedPreference === ExportPreference.Yes;
 }
 
-async function setdeleteCommentsPreference(
+async function setDeleteCommentsPreference(
   config: vscode.WorkspaceConfiguration,
   selectedPreference: string
 ) {
   const input = await vscode.window.showQuickPick(
-    ["Save my Preference", "Ask Every Time"],
+    [ExportPreference.Save, ExportPreference.Ask],
     {
       title:
-        selectedPreference === "Yes"
+        selectedPreference === ExportPreference.No
           ? "Delete comments on every export?"
           : "Keep comments on every export?",
       ignoreFocusOut: true,
@@ -55,7 +57,7 @@ async function setdeleteCommentsPreference(
 
   await config.update(
     "deleteCommentsOnExport",
-    input === "Save my Preference" ? selectedPreference : "Ask Every Time",
+    input === ExportPreference.Save ? selectedPreference : ExportPreference.Ask,
     true
   );
 }

--- a/src/utils/getDeleteCommentsPreference.ts
+++ b/src/utils/getDeleteCommentsPreference.ts
@@ -1,14 +1,15 @@
 import * as vscode from "vscode";
 
-import { ExportPreference } from "../types";
+import { QuickPick } from "../types";
 
 export default async function getDeleteCommentsPreference() {
   const config = vscode.workspace.getConfiguration("assay");
   const savedPreference =
-    config.get<string>("deleteCommentsOnExport") as ExportPreference || ExportPreference.None;
+    (config.get<string>("deleteCommentsOnExport") as QuickPick) ||
+    QuickPick.None;
 
-  if ([ExportPreference.Yes, ExportPreference.No].includes(savedPreference)) {
-    return savedPreference === ExportPreference.Yes;
+  if ([QuickPick.Yes, QuickPick.No].includes(savedPreference)) {
+    return savedPreference === QuickPick.Yes;
   } else {
     // No preference or ask every time.
     return await promptdeleteComments(config, savedPreference);
@@ -19,21 +20,24 @@ async function promptdeleteComments(
   config: vscode.WorkspaceConfiguration,
   savedPreference: string
 ) {
-  const selectedPreference = await vscode.window.showQuickPick([ExportPreference.Yes, ExportPreference.No], {
-    title: "Delete version comments after exporting?",
-    ignoreFocusOut: true,
-  });
+  const selectedPreference = await vscode.window.showQuickPick(
+    [QuickPick.Yes, QuickPick.No],
+    {
+      title: "Delete version comments after exporting?",
+      ignoreFocusOut: true,
+    }
+  );
 
   if (!selectedPreference) {
     return false;
   }
 
   // Ask to save preference.
-  if (savedPreference ===  ExportPreference.None) {
+  if (savedPreference === QuickPick.None) {
     await setDeleteCommentsPreference(config, selectedPreference);
   }
 
-  return selectedPreference === ExportPreference.Yes;
+  return selectedPreference === QuickPick.Yes;
 }
 
 async function setDeleteCommentsPreference(
@@ -41,10 +45,10 @@ async function setDeleteCommentsPreference(
   selectedPreference: string
 ) {
   const input = await vscode.window.showQuickPick(
-    [ExportPreference.Save, ExportPreference.Ask],
+    [QuickPick.Save, QuickPick.Ask],
     {
       title:
-        selectedPreference === ExportPreference.No
+        selectedPreference === QuickPick.No
           ? "Delete comments on every export?"
           : "Keep comments on every export?",
       ignoreFocusOut: true,
@@ -57,7 +61,7 @@ async function setDeleteCommentsPreference(
 
   await config.update(
     "deleteCommentsOnExport",
-    input === ExportPreference.Save ? selectedPreference : ExportPreference.Ask,
+    input === QuickPick.Save ? selectedPreference : QuickPick.Ask,
     true
   );
 }

--- a/test/suite/utils/AddonExtract.test.ts
+++ b/test/suite/utils/AddonExtract.test.ts
@@ -6,7 +6,7 @@ import path = require("path");
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 
-import { QuickPick } from "../../../src/types";
+import { QPOption } from "../../../src/types";
 import { extractAddon, dirExistsOrMake } from "../../../src/utils/addonExtract";
 
 const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
@@ -72,7 +72,7 @@ describe("AddonExtract.ts", async () => {
 
       // make a stub for the quickpick and force it to say yes
       const showQuickPickStub = sinon.stub();
-      showQuickPickStub.onCall(0).returns(QuickPick.Yes);
+      showQuickPickStub.onCall(0).returns(QPOption.Yes);
       sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
       await extractAddon(
@@ -109,7 +109,7 @@ describe("AddonExtract.ts", async () => {
 
       // make a stub for the quickpick and force it to say no
       const showQuickPickStub = sinon.stub();
-      showQuickPickStub.onCall(0).returns(QuickPick.No);
+      showQuickPickStub.onCall(0).returns(QPOption.No);
       sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
       try {

--- a/test/suite/utils/AddonExtract.test.ts
+++ b/test/suite/utils/AddonExtract.test.ts
@@ -6,6 +6,7 @@ import path = require("path");
 import * as sinon from "sinon";
 import * as vscode from "vscode";
 
+import { QuickPick } from "../../../src/types";
 import { extractAddon, dirExistsOrMake } from "../../../src/utils/addonExtract";
 
 const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
@@ -71,7 +72,7 @@ describe("AddonExtract.ts", async () => {
 
       // make a stub for the quickpick and force it to say yes
       const showQuickPickStub = sinon.stub();
-      showQuickPickStub.onCall(0).returns("Yes");
+      showQuickPickStub.onCall(0).returns(QuickPick.Yes);
       sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
       await extractAddon(
@@ -108,7 +109,7 @@ describe("AddonExtract.ts", async () => {
 
       // make a stub for the quickpick and force it to say no
       const showQuickPickStub = sinon.stub();
-      showQuickPickStub.onCall(0).returns("No");
+      showQuickPickStub.onCall(0).returns(QuickPick.No);
       sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
       try {

--- a/test/suite/utils/getDeleteCommentsPreference.test.ts
+++ b/test/suite/utils/getDeleteCommentsPreference.test.ts
@@ -5,7 +5,7 @@ import * as sinon from "sinon";
 import * as vscode from "vscode";
 
 import { setExtensionStoragePath } from "../../../src/config/globals";
-import { QuickPick } from "../../../src/types";
+import { QPOption } from "../../../src/types";
 import getDeleteCommentsPreference from "../../../src/utils/getDeleteCommentsPreference";
 
 const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
@@ -22,7 +22,7 @@ describe("getdeleteComments.ts", () => {
         it("should return true when user's preference is to delete comments after export.", async () => {
             const configStub = sinon.stub(vscode.workspace, "getConfiguration");
             const config = {
-                get: sinon.stub().returns(QuickPick.Yes),
+                get: sinon.stub().returns(QPOption.Yes),
             } as unknown as vscode.WorkspaceConfiguration;
             configStub.returns(config);
 
@@ -33,7 +33,7 @@ describe("getdeleteComments.ts", () => {
         it("should return false when user's preference is to not delete comments after export.", async () => {
             const configStub = sinon.stub(vscode.workspace, "getConfiguration");
             const config = {
-                get: sinon.stub().returns(QuickPick.No),
+                get: sinon.stub().returns(QPOption.No),
             } as unknown as vscode.WorkspaceConfiguration;
             configStub.returns(config);
 
@@ -44,7 +44,7 @@ describe("getdeleteComments.ts", () => {
         it("should prompt the user when their preference is to be asked every time, and return false on no response.", async () => {
             const configStub = sinon.stub(vscode.workspace, "getConfiguration");
             const config = {
-                get: sinon.stub().returns(QuickPick.Ask),
+                get: sinon.stub().returns(QPOption.Ask),
             } as unknown as vscode.WorkspaceConfiguration;
             configStub.returns(config);
 
@@ -59,12 +59,12 @@ describe("getdeleteComments.ts", () => {
         it("should prompt the user when their preference is to be asked every time, and return their selection 'Yes' (true).", async () => {
             const configStub = sinon.stub(vscode.workspace, "getConfiguration");
             const config = {
-                get: sinon.stub().returns(QuickPick.Ask),
+                get: sinon.stub().returns(QPOption.Ask),
             } as unknown as vscode.WorkspaceConfiguration;
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onCall(0).returns(QuickPick.Yes);
+            showQuickPickStub.onCall(0).returns(QPOption.Yes);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
             const result = await getDeleteCommentsPreference();
@@ -74,12 +74,12 @@ describe("getdeleteComments.ts", () => {
         it("should prompt the user when their preference is to be asked every time, and return their selection 'No' (false).", async () => {
             const configStub = sinon.stub(vscode.workspace, "getConfiguration");
             const config = {
-                get: sinon.stub().returns(QuickPick.Ask),
+                get: sinon.stub().returns(QPOption.Ask),
             } as unknown as vscode.WorkspaceConfiguration;
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onCall(0).returns(QuickPick.No);
+            showQuickPickStub.onCall(0).returns(QPOption.No);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
             const result = await getDeleteCommentsPreference();
@@ -97,14 +97,14 @@ describe("getdeleteComments.ts", () => {
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onFirstCall().resolves(QuickPick.Yes);
-            showQuickPickStub.onSecondCall().resolves(QuickPick.Save);
+            showQuickPickStub.onFirstCall().resolves(QPOption.Yes);
+            showQuickPickStub.onSecondCall().resolves(QPOption.Save);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
             const result = await getDeleteCommentsPreference();
             expect(result).to.be.true;
             expect(updateStub.calledOnce).to.be.true;
-            expect(updateStub.calledWith("deleteCommentsOnExport", QuickPick.Yes, true)).to.be.true;
+            expect(updateStub.calledWith("deleteCommentsOnExport", QPOption.Yes, true)).to.be.true;
         });
 
         it("should prompt the user twice when their preference is not defined: once for their preference ('Yes') and once to save ('Ask Every Time') then save, and then return preference.", async () => {
@@ -118,14 +118,14 @@ describe("getdeleteComments.ts", () => {
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onFirstCall().resolves(QuickPick.Yes);
-            showQuickPickStub.onSecondCall().resolves(QuickPick.Ask);
+            showQuickPickStub.onFirstCall().resolves(QPOption.Yes);
+            showQuickPickStub.onSecondCall().resolves(QPOption.Ask);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
             const result = await getDeleteCommentsPreference();
             expect(result).to.be.true;
             expect(updateStub.calledOnce).to.be.true;
-            expect(updateStub.calledWith("deleteCommentsOnExport", QuickPick.Ask, true)).to.be.true;
+            expect(updateStub.calledWith("deleteCommentsOnExport", QPOption.Ask, true)).to.be.true;
         });
 
         it("should prompt the user twice when their preference is not defined: once for their preference ('No') and once to save ('Save my preference') then save, and then return preference.", async () => {
@@ -139,14 +139,14 @@ describe("getdeleteComments.ts", () => {
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onFirstCall().resolves(QuickPick.No);
-            showQuickPickStub.onSecondCall().resolves(QuickPick.Save);
+            showQuickPickStub.onFirstCall().resolves(QPOption.No);
+            showQuickPickStub.onSecondCall().resolves(QPOption.Save);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
             const result = await getDeleteCommentsPreference();
             expect(result).to.be.false;
             expect(updateStub.calledOnce).to.be.true;
-            expect(updateStub.calledWith("deleteCommentsOnExport", QuickPick.No, true)).to.be.true;
+            expect(updateStub.calledWith("deleteCommentsOnExport", QPOption.No, true)).to.be.true;
         });
 
         it("should prompt the user twice when their preference is not defined: once for their preference ('No') and once to save ('Ask Every Time') then save, and then return preference.", async () => {
@@ -160,14 +160,14 @@ describe("getdeleteComments.ts", () => {
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onFirstCall().resolves(QuickPick.No);
-            showQuickPickStub.onSecondCall().resolves(QuickPick.Ask);
+            showQuickPickStub.onFirstCall().resolves(QPOption.No);
+            showQuickPickStub.onSecondCall().resolves(QPOption.Ask);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
             const result = await getDeleteCommentsPreference();
             expect(result).to.be.false;
             expect(updateStub.calledOnce).to.be.true;
-            expect(updateStub.calledWith("deleteCommentsOnExport", QuickPick.Ask, true)).to.be.true;
+            expect(updateStub.calledWith("deleteCommentsOnExport", QPOption.Ask, true)).to.be.true;
         });
 
         it("should prompt the user twice when their preference is not defined: once for their preference  and once to save (early termination).", async () => {
@@ -181,7 +181,7 @@ describe("getdeleteComments.ts", () => {
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onFirstCall().resolves(QuickPick.No);
+            showQuickPickStub.onFirstCall().resolves(QPOption.No);
             showQuickPickStub.onSecondCall().resolves(undefined);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 

--- a/test/suite/utils/getDeleteCommentsPreference.test.ts
+++ b/test/suite/utils/getDeleteCommentsPreference.test.ts
@@ -5,6 +5,7 @@ import * as sinon from "sinon";
 import * as vscode from "vscode";
 
 import { setExtensionStoragePath } from "../../../src/config/globals";
+import { QuickPick } from "../../../src/types";
 import getDeleteCommentsPreference from "../../../src/utils/getDeleteCommentsPreference";
 
 const workspaceFolder = path.resolve(__dirname, "..", "test_workspace");
@@ -21,7 +22,7 @@ describe("getdeleteComments.ts", () => {
         it("should return true when user's preference is to delete comments after export.", async () => {
             const configStub = sinon.stub(vscode.workspace, "getConfiguration");
             const config = {
-                get: sinon.stub().returns("Yes"),
+                get: sinon.stub().returns(QuickPick.Yes),
             } as unknown as vscode.WorkspaceConfiguration;
             configStub.returns(config);
 
@@ -32,7 +33,7 @@ describe("getdeleteComments.ts", () => {
         it("should return false when user's preference is to not delete comments after export.", async () => {
             const configStub = sinon.stub(vscode.workspace, "getConfiguration");
             const config = {
-                get: sinon.stub().returns("No"),
+                get: sinon.stub().returns(QuickPick.No),
             } as unknown as vscode.WorkspaceConfiguration;
             configStub.returns(config);
 
@@ -43,7 +44,7 @@ describe("getdeleteComments.ts", () => {
         it("should prompt the user when their preference is to be asked every time, and return false on no response.", async () => {
             const configStub = sinon.stub(vscode.workspace, "getConfiguration");
             const config = {
-                get: sinon.stub().returns("Ask Every Time"),
+                get: sinon.stub().returns(QuickPick.Ask),
             } as unknown as vscode.WorkspaceConfiguration;
             configStub.returns(config);
 
@@ -58,12 +59,12 @@ describe("getdeleteComments.ts", () => {
         it("should prompt the user when their preference is to be asked every time, and return their selection 'Yes' (true).", async () => {
             const configStub = sinon.stub(vscode.workspace, "getConfiguration");
             const config = {
-                get: sinon.stub().returns("Ask Every Time"),
+                get: sinon.stub().returns(QuickPick.Ask),
             } as unknown as vscode.WorkspaceConfiguration;
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onCall(0).returns("Yes");
+            showQuickPickStub.onCall(0).returns(QuickPick.Yes);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
             const result = await getDeleteCommentsPreference();
@@ -73,12 +74,12 @@ describe("getdeleteComments.ts", () => {
         it("should prompt the user when their preference is to be asked every time, and return their selection 'No' (false).", async () => {
             const configStub = sinon.stub(vscode.workspace, "getConfiguration");
             const config = {
-                get: sinon.stub().returns("Ask Every Time"),
+                get: sinon.stub().returns(QuickPick.Ask),
             } as unknown as vscode.WorkspaceConfiguration;
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onCall(0).returns("No");
+            showQuickPickStub.onCall(0).returns(QuickPick.No);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
             const result = await getDeleteCommentsPreference();
@@ -96,14 +97,14 @@ describe("getdeleteComments.ts", () => {
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onFirstCall().resolves("Yes");
-            showQuickPickStub.onSecondCall().resolves("Save my Preference");
+            showQuickPickStub.onFirstCall().resolves(QuickPick.Yes);
+            showQuickPickStub.onSecondCall().resolves(QuickPick.Save);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
             const result = await getDeleteCommentsPreference();
             expect(result).to.be.true;
             expect(updateStub.calledOnce).to.be.true;
-            expect(updateStub.calledWith("deleteCommentsOnExport", "Yes", true)).to.be.true;
+            expect(updateStub.calledWith("deleteCommentsOnExport", QuickPick.Yes, true)).to.be.true;
         });
 
         it("should prompt the user twice when their preference is not defined: once for their preference ('Yes') and once to save ('Ask Every Time') then save, and then return preference.", async () => {
@@ -117,14 +118,14 @@ describe("getdeleteComments.ts", () => {
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onFirstCall().resolves("Yes");
-            showQuickPickStub.onSecondCall().resolves("Ask Every Time");
+            showQuickPickStub.onFirstCall().resolves(QuickPick.Yes);
+            showQuickPickStub.onSecondCall().resolves(QuickPick.Ask);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
             const result = await getDeleteCommentsPreference();
             expect(result).to.be.true;
             expect(updateStub.calledOnce).to.be.true;
-            expect(updateStub.calledWith("deleteCommentsOnExport", "Ask Every Time", true)).to.be.true;
+            expect(updateStub.calledWith("deleteCommentsOnExport", QuickPick.Ask, true)).to.be.true;
         });
 
         it("should prompt the user twice when their preference is not defined: once for their preference ('No') and once to save ('Save my preference') then save, and then return preference.", async () => {
@@ -138,14 +139,14 @@ describe("getdeleteComments.ts", () => {
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onFirstCall().resolves("No");
-            showQuickPickStub.onSecondCall().resolves("Save my Preference");
+            showQuickPickStub.onFirstCall().resolves(QuickPick.No);
+            showQuickPickStub.onSecondCall().resolves(QuickPick.Save);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
             const result = await getDeleteCommentsPreference();
             expect(result).to.be.false;
             expect(updateStub.calledOnce).to.be.true;
-            expect(updateStub.calledWith("deleteCommentsOnExport", "No", true)).to.be.true;
+            expect(updateStub.calledWith("deleteCommentsOnExport", QuickPick.No, true)).to.be.true;
         });
 
         it("should prompt the user twice when their preference is not defined: once for their preference ('No') and once to save ('Ask Every Time') then save, and then return preference.", async () => {
@@ -159,14 +160,14 @@ describe("getdeleteComments.ts", () => {
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onFirstCall().resolves("No");
-            showQuickPickStub.onSecondCall().resolves("Ask Every Time");
+            showQuickPickStub.onFirstCall().resolves(QuickPick.No);
+            showQuickPickStub.onSecondCall().resolves(QuickPick.Ask);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 
             const result = await getDeleteCommentsPreference();
             expect(result).to.be.false;
             expect(updateStub.calledOnce).to.be.true;
-            expect(updateStub.calledWith("deleteCommentsOnExport", "Ask Every Time", true)).to.be.true;
+            expect(updateStub.calledWith("deleteCommentsOnExport", QuickPick.Ask, true)).to.be.true;
         });
 
         it("should prompt the user twice when their preference is not defined: once for their preference  and once to save (early termination).", async () => {
@@ -180,7 +181,7 @@ describe("getdeleteComments.ts", () => {
             configStub.returns(config);
 
             const showQuickPickStub = sinon.stub();
-            showQuickPickStub.onFirstCall().resolves("No");
+            showQuickPickStub.onFirstCall().resolves(QuickPick.No);
             showQuickPickStub.onSecondCall().resolves(undefined);
             sinon.replace(vscode.window, "showQuickPick", showQuickPickStub);
 


### PR DESCRIPTION
Closes #53 

**Changes**
- Changed areas that use QuickPicks to utilize an Enum `QPOption` for its options.