### PR TITLE
Add Prompt Before Opening File Dialog

### DIFF
--- a/src/views/rootView.ts
+++ b/src/views/rootView.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode";
 
 export class RootView {
-  // TODO: very sudden. do a prompt before it first
   static async selectRootFolder() {
     const options: vscode.OpenDialogOptions = {
       canSelectFiles: false,

--- a/src/views/rootView.ts
+++ b/src/views/rootView.ts
@@ -10,11 +10,23 @@ export class RootView {
     };
 
     let selectedFolders: vscode.Uri[] | undefined;
-    const selectButton = { title: "Select Addon Root Folder", isCloseAffordance: true };
-    await vscode.window.showInformationMessage("Assay: No root directory found.", { detail: "Select the folder where add-ons should be installed.", modal: true }, selectButton).then(async () => {
-      selectedFolders = await vscode.window.showOpenDialog(options);
-    });
-    
+    const selectButton = {
+      title: "Select Addon Root Folder",
+      isCloseAffordance: true,
+    };
+    await vscode.window
+      .showInformationMessage(
+        "Assay: No root directory found.",
+        {
+          detail: "Select the folder where add-ons should be installed.",
+          modal: true,
+        },
+        selectButton
+      )
+      .then(async () => {
+        selectedFolders = await vscode.window.showOpenDialog(options);
+      });
+
     if (selectedFolders && selectedFolders.length > 0) {
       return selectedFolders[0].fsPath;
     }

--- a/src/views/rootView.ts
+++ b/src/views/rootView.ts
@@ -10,7 +10,12 @@ export class RootView {
       openLabel: "Select Addon Review Workspace",
     };
 
-    const selectedFolders = await vscode.window.showOpenDialog(options);
+    let selectedFolders: vscode.Uri[] | undefined;
+    const selectButton = { title: "Select Addon Root Folder", isCloseAffordance: true };
+    await vscode.window.showInformationMessage("Assay: No root directory found.", { detail: "Select the folder where add-ons should be installed.", modal: true }, selectButton).then(async () => {
+      selectedFolders = await vscode.window.showOpenDialog(options);
+    });
+    
     if (selectedFolders && selectedFolders.length > 0) {
       return selectedFolders[0].fsPath;
     }

--- a/test/suite/controller/directoryController.test.ts
+++ b/test/suite/controller/directoryController.test.ts
@@ -49,6 +49,8 @@ describe("directoryController.ts", async () => {
 
     it("should throw an error if the folder is not set.", async () => {
         const configStub = sinon.stub(vscode.workspace, "getConfiguration");
+        sinon.stub(vscode.window, 'showInformationMessage').resolves();
+
         const assayConfig = {
             update: sinon.stub(),
             get: () => {
@@ -85,6 +87,8 @@ describe("directoryController.ts", async () => {
 
     it("should return the new folder if the old one doesn't exist.", async () => {
         const configStub = sinon.stub(vscode.workspace, "getConfiguration");
+        const showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves();
+
         const assayConfig = {
             get: () => {
             return undefined;
@@ -106,7 +110,7 @@ describe("directoryController.ts", async () => {
         };
 
         configStub.withArgs("assay").returns(assayConfig);
-    configStub.withArgs("files").returns(fileConfig);
+        configStub.withArgs("files").returns(fileConfig);
 
         const directoryController = new DirectoryController();
 
@@ -115,6 +119,7 @@ describe("directoryController.ts", async () => {
         showOpenDialogStub.resolves([uri]);
 
         const result = await directoryController.getRootFolderPath();
+        expect(showInformationMessageStub.called).to.be.true;
         expect(result).to.equal("/test");
     });
   });

--- a/test/suite/views/rootView.test.ts
+++ b/test/suite/views/rootView.test.ts
@@ -14,18 +14,23 @@ describe("rootView.ts", () => {
     describe("selectRootFolder()", async () => {
         it("should return undefined if no folder is chosen.", async () => { 
             const showOpenDialogStub = sinon.stub(vscode.window, "showOpenDialog");
+            const showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves();
             showOpenDialogStub.resolves(undefined);
 
             const result = await RootView.selectRootFolder();
+            expect(showInformationMessageStub.called).to.be.true;
             expect(result).to.be.undefined;
         });
 
         it("should return the chosen folder.", async () => {
             const showOpenDialogStub = sinon.stub(vscode.window, "showOpenDialog");
+            const showInformationMessageStub = sinon.stub(vscode.window, 'showInformationMessage').resolves();
+        
             const uri = vscode.Uri.file("test");
             showOpenDialogStub.resolves([uri]);
 
             const result = await RootView.selectRootFolder();
+            expect(showInformationMessageStub.called).to.be.true;
             expect(result).to.equal("/test");
         });
     });


### PR DESCRIPTION
When no root folder exists, Assay prompts the user to select one. Since this is done every time the root folder is checked for, there is a chance this is the first thing the user encounters after installing Assay. Added a modal to explain the situation to the user before prompting to select a root folder to alleviate some confusion.

![image](https://github.com/mozilla/assay/assets/44586776/42c774e6-7db0-4460-87be-617a7bd1e6c8)

A future improvement could be to avoid these checks until the user completes setup through the Assay sidebar.
