### PR TITLE
Moved "Export Comments" and "Delete Comments" Options to Sidebar Rather Than File Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,9 +229,6 @@
 					"when": "assay.commentsEnabled && commentController == assay-comments && commentThreadIsEmpty"
 				}
 			],
-			"comments/comment/title": [
-				
-			],
 			"comments/comment/context": [
 				{
 					"command": "assay.cancelSaveComment",

--- a/package.json
+++ b/package.json
@@ -171,34 +171,28 @@
       "view/item/context": [
         {
           "command": "assay.sidebarDiff",
+          "group": "primary@1",
           "when": "viewItem !== guidDirectory && view == assayCommands && listDoubleSelection"
         },
         {
           "command": "assay.sidebarDelete",
+          "group": "secondary@1",
           "when": "view == assayCommands"
         },
         {
           "command": "assay.viewAddon",
           "group": "inline",
           "when": "viewItem !== guidDirectory && view == assayCommands"
-        }
-      ],
-      "explorer/context": [
-        {
-          
-          "command": "assay.openInDiffTool",
-          "group": "navigation",
-          "when": "assay.commentsEnabled && explorerResourceIsFolder && listDoubleSelection"
         },
         {
-          "command": "assay.exportCommentsFromContext",
-          "group": "navigation",
-          "when": "assay.commentsEnabled && explorerResourceIsFolder"
+          "command": "assay.exportComments",
+          "group": "primary@2",
+          "when": "viewItem !== guidDirectory && assay.commentsEnabled && !listMultiSelection"
         },
         {
           "command": "assay.deleteCommentsFromContext",
-          "group": "navigation",
-          "when": "explorerResourceIsFolder"
+          "group": "primary@3",
+          "when": "viewItem !== guidDirectory && assay.commentsEnabled"
         }
       ],
       "comments/commentThread/title": [
@@ -284,12 +278,8 @@
         "title": "(Assay) Open in Diff Tool"
       },
       {
-        "command": "assay.exportCommentsFromContext",
-        "title": "(Assay) Export Version Comments"
-      },
-      {
         "command": "assay.deleteCommentsFromContext",
-        "title": "(Assay) Delete Version Comments"
+        "title": "Delete Comments"
       },
       {
         "command": "assay.checkForUpdates",
@@ -311,7 +301,7 @@
       },
       {
         "command": "assay.sidebarDelete",
-        "title": "Delete"
+        "title": "Delete Selected"
       },
       {
         "command": "assay.viewAddon",
@@ -358,7 +348,7 @@
 			},
       {
 				"command": "assay.exportComments",
-				"title": "Export Version Comments",
+				"title": "Export Comments",
         "icon": "$(assay-export)"
 			},
       {

--- a/src/controller/commentCacheController.ts
+++ b/src/controller/commentCacheController.ts
@@ -143,6 +143,12 @@ export class CommentCacheController {
     compiledComments: string,
     uri: vscode.Uri
   ) {
+
+    if(compiledComments.length < 1 ){
+      vscode.window.showInformationMessage("No comments to export.");
+      return false;
+    }
+
     const document = await vscode.workspace.openTextDocument({
       content: compiledComments,
       language: "text",

--- a/src/controller/commentCacheController.ts
+++ b/src/controller/commentCacheController.ts
@@ -143,8 +143,7 @@ export class CommentCacheController {
     compiledComments: string,
     uri: vscode.Uri
   ) {
-
-    if(compiledComments.length < 1 ){
+    if (compiledComments.length < 1) {
       vscode.window.showInformationMessage("No comments to export.");
       return false;
     }

--- a/src/controller/commentController.ts
+++ b/src/controller/commentController.ts
@@ -25,10 +25,13 @@ export class CommentController {
    * @param list Selected AddonTreeItems
    * @returns whether all were successfully deleted.
    */
-  async deleteCommentsFromMenu(treeItem: AddonTreeItem, list: AddonTreeItem[] | undefined) {
+  async deleteCommentsFromMenu(
+    treeItem: AddonTreeItem,
+    list: AddonTreeItem[] | undefined
+  ) {
     let success = false;
     list = list || [treeItem];
-    for(const item of list){
+    for (const item of list) {
       await this.commentCacheController.deleteComments(item.uri);
       success = true;
     }

--- a/src/controller/commentController.ts
+++ b/src/controller/commentController.ts
@@ -29,14 +29,18 @@ export class CommentController {
     treeItem: AddonTreeItem,
     list: AddonTreeItem[] | undefined
   ) {
-    let success = false;
+    const promises = [];
+    const failedUris: vscode.Uri[] = [];
     list = list || [treeItem];
+
     for (const item of list) {
-      await this.commentCacheController.deleteComments(item.uri);
-      success = true;
+        const promise = this.commentCacheController.deleteComments(item.uri).catch(() => failedUris.push(item.uri));
+        promises.push(promise);
     }
+
+    await Promise.allSettled(promises);
     this.refetchComments();
-    return success;
+    return failedUris;
   }
 
   /**

--- a/src/controller/commentController.ts
+++ b/src/controller/commentController.ts
@@ -4,6 +4,7 @@ import { CommentCacheController } from "./commentCacheController";
 import { DirectoryController } from "./directoryController";
 import { RangeHelper } from "../helper/rangeHelper";
 import { AssayComment, AssayReply, AssayThread } from "../model/assayComment";
+import { AddonTreeItem } from "../model/sidebarTreeDataProvider";
 import { ContextValues } from "../types";
 export class CommentController {
   controller: vscode.CommentController;
@@ -16,6 +17,23 @@ export class CommentController {
   ) {
     this.controller = vscode.comments.createCommentController(id, label);
     this.activateController();
+  }
+
+  /**
+   * Deletes the comments from the selected uris.
+   * @param treeItem The specific AddonTreeItem the user opened the context menu on.
+   * @param list Selected AddonTreeItems
+   * @returns whether all were successfully deleted.
+   */
+  async deleteCommentsFromMenu(treeItem: AddonTreeItem, list: AddonTreeItem[] | undefined) {
+    let success = false;
+    list = list || [treeItem];
+    for(const item of list){
+      await this.commentCacheController.deleteComments(item.uri);
+      success = true;
+    }
+    this.refetchComments();
+    return success;
   }
 
   /**
@@ -100,11 +118,11 @@ export class CommentController {
   }
 
   /**
-   * Export comments from current version.
+   * Export comments from current version via menu.
    */
-  async exportComments(thread: AssayThread) {
+  async exportComments(item: AssayThread | AddonTreeItem) {
     const didDelete = await this.commentCacheController.exportVersionComments(
-      thread.uri
+      item.uri
     );
     if (didDelete) {
       this.refetchComments();

--- a/src/controller/commentController.ts
+++ b/src/controller/commentController.ts
@@ -38,7 +38,7 @@ export class CommentController {
         promises.push(promise);
     }
 
-    await Promise.allSettled(promises);
+    await Promise.all(promises);
     this.refetchComments();
     return failedUris;
   }

--- a/src/controller/diffController.ts
+++ b/src/controller/diffController.ts
@@ -60,7 +60,7 @@ export class DiffController {
    */
   private async setDiffCommand() {
     try {
-      const input = await DiffView.promptDiffCommand();
+      const input = DiffView.promptDiffCommand();
       const config = vscode.workspace.getConfiguration("assay");
       await config.update("diffTool", input, true);
       return input;

--- a/src/controller/sidebarController.ts
+++ b/src/controller/sidebarController.ts
@@ -1,7 +1,10 @@
 import * as vscode from "vscode";
 
 import { DirectoryController } from "./directoryController";
-import { AddonTreeDataProvider, AddonTreeItem } from "../model/sidebarTreeDataProvider";
+import {
+  AddonTreeDataProvider,
+  AddonTreeItem,
+} from "../model/sidebarTreeDataProvider";
 
 export class SidebarController {
   public refresh: () => void;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import { UrlController } from "./controller/urlController";
 import { UpdateHelper } from "./helper/updateHelper";
 import { AssayCache } from "./model/assayCache";
 import { CustomFileDecorationProvider } from "./model/fileDecorationProvider";
+import { AddonTreeItem } from "./model/sidebarTreeDataProvider";
 import { WelcomeView } from "./views/welcomeView";
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -40,8 +41,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const sidebarDeleteDisposable = vscode.commands.registerCommand(
     "assay.sidebarDelete",
-    sidebarController.delete,
-    sidebarController
+    (treeItem: AddonTreeItem, list: AddonTreeItem[]) => {
+      commentController.deleteCommentsFromMenu(treeItem, list);
+      sidebarController.delete(treeItem, list);
+    }
   );
 
   const addonController = new AddonController(
@@ -206,16 +209,10 @@ export async function activate(context: vscode.ExtensionContext) {
     statusBarController
   );
 
-  const exportCommentsFolderDisposable = vscode.commands.registerCommand(
-    "assay.exportCommentsFromContext",
-    commentCacheController.exportVersionComments,
-    commentCacheController
-  );
-
   const deleteCommentsFolderDisposable = vscode.commands.registerCommand(
     "assay.deleteCommentsFromContext",
-    commentCacheController.deleteComments,
-    commentCacheController
+    commentController.deleteCommentsFromMenu,
+    commentController
   );
 
   const exportCommentDisposable = vscode.commands.registerCommand(
@@ -284,7 +281,6 @@ export async function activate(context: vscode.ExtensionContext) {
     disposeCommentDisposable,
     copyLinkFromReplyDisposable,
     copyLinkFromThreadDisposable,
-    exportCommentsFolderDisposable,
     deleteCommentsFolderDisposable
   );
 }

--- a/src/model/sidebarTreeDataProvider.ts
+++ b/src/model/sidebarTreeDataProvider.ts
@@ -15,7 +15,9 @@ export class AddonTreeItem extends vscode.TreeItem {
 
     super(label, collapsibleState);
     this.contextValue = isGuidFolder ? "guidDirectory" : undefined;
-    this.iconPath = isGuidFolder ? new vscode.ThemeIcon("assay-addon") : undefined;
+    this.iconPath = isGuidFolder
+      ? new vscode.ThemeIcon("assay-addon")
+      : undefined;
   }
 }
 

--- a/test/suite/controller/commentController.test.ts
+++ b/test/suite/controller/commentController.test.ts
@@ -236,12 +236,13 @@ describe("CommentController.ts", () => {
     it("delete the comments of the given uri.", async () => {
       const uri = vscode.Uri.parse("uri");      
       const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
+      commentCacheControllerStub.deleteComments.resolves();
       const result = await cmtController.deleteCommentsFromMenu({
         label: "",
         uri: uri
       }, undefined);
       expect(commentCacheControllerStub.deleteComments.calledWith(uri)).to.be.true;
-      expect(result).to.be.true;
+      expect(result).to.have.lengthOf(0);
     });
 
     it("delete the comments of given uris.", async () => {
@@ -250,6 +251,7 @@ describe("CommentController.ts", () => {
       const uriThree = vscode.Uri.parse("uri-three");      
 
       const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
+      commentCacheControllerStub.deleteComments.resolves();
       const result = await cmtController.deleteCommentsFromMenu({
         label: "",
         uri: uriOne
@@ -268,8 +270,7 @@ describe("CommentController.ts", () => {
       expect(commentCacheControllerStub.deleteComments.calledWith(uriOne)).to.be.true;
       expect(commentCacheControllerStub.deleteComments.calledWith(uriTwo)).to.be.true;
       expect(commentCacheControllerStub.deleteComments.calledWith(uriThree)).to.be.true;
-
-      expect(result).to.be.true;
+      expect(result).to.have.lengthOf(0);
     });
   });
 

--- a/test/suite/controller/commentController.test.ts
+++ b/test/suite/controller/commentController.test.ts
@@ -232,6 +232,47 @@ describe("CommentController.ts", () => {
     });
 });
 
+  describe("deleteCommentsFromMenu()", () => {
+    it("delete the comments of the given uri.", async () => {
+      const uri = vscode.Uri.parse("uri");      
+      const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
+      const result = await cmtController.deleteCommentsFromMenu({
+        label: "",
+        uri: uri
+      }, undefined);
+      expect(commentCacheControllerStub.deleteComments.calledWith(uri)).to.be.true;
+      expect(result).to.be.true;
+    });
+
+    it("delete the comments of given uris.", async () => {
+      const uriOne = vscode.Uri.parse("uri-one");
+      const uriTwo = vscode.Uri.parse("uri-two");      
+      const uriThree = vscode.Uri.parse("uri-three");      
+
+      const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
+      const result = await cmtController.deleteCommentsFromMenu({
+        label: "",
+        uri: uriOne
+      }, [{
+        label: "",
+        uri: uriOne
+      },
+      {
+        label: "",
+        uri: uriTwo
+      },
+      {
+        label: "",
+        uri: uriThree
+      }]);
+      expect(commentCacheControllerStub.deleteComments.calledWith(uriOne)).to.be.true;
+      expect(commentCacheControllerStub.deleteComments.calledWith(uriTwo)).to.be.true;
+      expect(commentCacheControllerStub.deleteComments.calledWith(uriThree)).to.be.true;
+
+      expect(result).to.be.true;
+    });
+  });
+
 
   describe("exportComments()", () => {
     it("call to export comments from cache and activate a new controller with re-fetched comments in place of the old one.", async () => {


### PR DESCRIPTION
**Changes**
- Moved exporting comments and deleting comments from the explorer menu to the dedicated Assay menu for consistency.
- When a version is deleted, deletes the comments stored in cache.