### PR TITLE
Remove Commenting Functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,14 +127,6 @@
           "when": "false"
         },
         {
-          "command": "assay.saveComment",
-          "when": "false"
-        },
-        {
-          "command": "assay.cancelSaveComment",
-          "when": "false"
-        },
-        {
           "command": "assay.disposeComment",
           "when": "false"
         },
@@ -143,7 +135,7 @@
           "when": "false"
         },
         {
-          "command": "assay.copyLinkFromThread",
+          "command": "assay.copyLink",
           "when": "false"
         }
       ],
@@ -194,7 +186,7 @@
           "when": "assay.commentsEnabled && !commentThreadIsEmpty"
 				},
         {
-					"command": "assay.copyLinkFromThread",
+					"command": "assay.copyLink",
 					"group": "inline@3",
           "when": "assay.commentsEnabled && !commentThreadIsEmpty"
 				},
@@ -204,18 +196,6 @@
 					"when": "assay.commentsEnabled && commentController == assay-comments && !commentThreadIsEmpty"
 				}
       ],
-			"comments/comment/context": [
-				{
-					"command": "assay.cancelSaveComment",
-					"group": "inline@3",
-					"when": "assay.commentsEnabled && commentController == assay-comments"
-				},
-				{
-					"command": "assay.saveComment",
-					"group": "inline@2",
-					"when": "assay.commentsEnabled && commentController == assay-comments"
-				}
-			],
       "editor/context": [
         {
           "command": "assay.addComment",
@@ -284,7 +264,7 @@
       },
       {
         "command": "assay.viewAddon",
-        "title": "View Addon in New Window",
+        "title": "View Addon",
         "icon": "$(assay-view)"
       },
       {
@@ -297,24 +277,12 @@
       },
       {
 				"command": "assay.addComment",
-				"title": "Mark for Review"
-			},
-      {
-				"command": "assay.addComment",
 				"title": "(Assay) Mark for Review"
 			},
 			{
 				"command": "assay.deleteComment",
 				"title": "Delete",
 				"icon": "$(assay-delete)"
-			},
-			{
-				"command": "assay.saveComment",
-				"title": "Save"
-			},
-			{
-				"command": "assay.cancelSaveComment",
-				"title": "Cancel"
 			},
 			{
 				"command": "assay.disposeComment",
@@ -326,7 +294,7 @@
         "icon": "$(assay-export)"
 			},
       {
-				"command": "assay.copyLinkFromThread",
+				"command": "assay.copyLink",
 				"title": "Copy Link",
 				"icon": "$(assay-share)"
 			}

--- a/package.json
+++ b/package.json
@@ -119,15 +119,7 @@
           "when": "false"
         },
         {
-          "command": "assay.copyLinkFromReply",
-          "when": "false"
-        },
-        {
           "command": "assay.addComment",
-          "when": "false"
-        },
-        {
-          "command": "assay.editComment",
           "when": "false"
         },
         {
@@ -202,11 +194,6 @@
           "when": "assay.commentsEnabled && !commentThreadIsEmpty"
 				},
         {
-					"command": "assay.editComment",
-					"group": "inline@2",
-					"when": "assay.commentsEnabled && commentController == assay-comments && !commentThreadIsEmpty"
-				},
-        {
 					"command": "assay.copyLinkFromThread",
 					"group": "inline@3",
           "when": "assay.commentsEnabled && !commentThreadIsEmpty"
@@ -217,18 +204,6 @@
 					"when": "assay.commentsEnabled && commentController == assay-comments && !commentThreadIsEmpty"
 				}
       ],
-      "comments/commentThread/context": [
-        {
-					"command": "assay.addComment",
-					"group": "inline@1",
-					"when": "assay.commentsEnabled && commentController == assay-comments && commentThreadIsEmpty"
-				},
-        {
-					"command": "assay.copyLinkFromReply",
-					"group": "inline@2",
-					"when": "assay.commentsEnabled && commentController == assay-comments && commentThreadIsEmpty"
-				}
-			],
 			"comments/comment/context": [
 				{
 					"command": "assay.cancelSaveComment",
@@ -240,7 +215,14 @@
 					"group": "inline@2",
 					"when": "assay.commentsEnabled && commentController == assay-comments"
 				}
-			]
+			],
+      "editor/context": [
+        {
+          "command": "assay.addComment",
+          "when": "editorTextFocus",
+          "group": "navigation"
+        }
+      ]
     },
     "viewsContainers": {
       "activitybar": [
@@ -314,17 +296,12 @@
         "title": "(Assay) Enter Secret Key"
       },
       {
-				"command": "assay.copyLinkFromReply",
-				"title": "Copy Link"
-			},
-      {
 				"command": "assay.addComment",
 				"title": "Mark for Review"
 			},
-			{
-				"command": "assay.editComment",
-				"title": "Edit Comment",
-				"icon": "$(assay-edit)"
+      {
+				"command": "assay.addComment",
+				"title": "(Assay) Mark for Review"
 			},
 			{
 				"command": "assay.deleteComment",

--- a/src/controller/addonController.ts
+++ b/src/controller/addonController.ts
@@ -1,7 +1,7 @@
 import * as extract from "extract-zip";
 import * as fs from "fs";
 import fetch from "node-fetch";
-import * as path from "path";  
+import * as path from "path";
 import * as vscode from "vscode";
 
 import { AddonCacheController } from "./addonCacheController";
@@ -83,7 +83,10 @@ export class AddonController {
 
       const workspaceFolder =
         await this.directoryController.getRootFolderPath();
-      const compressedFilePath = path.join(workspaceFolder, `${guid}_${version}.xpi`);
+      const compressedFilePath = path.join(
+        workspaceFolder,
+        `${guid}_${version}.xpi`
+      );
 
       this.addonCacheController.addAddonToCache(guid, {
         reviewUrl: json.review_url,

--- a/src/controller/commentCacheController.ts
+++ b/src/controller/commentCacheController.ts
@@ -1,4 +1,4 @@
-import * as path from "path";  
+import * as path from "path";
 import * as vscode from "vscode";
 
 import { DirectoryController } from "./directoryController";

--- a/src/controller/commentCacheController.ts
+++ b/src/controller/commentCacheController.ts
@@ -90,11 +90,9 @@ export class CommentCacheController {
 
     for (const filepath in comments) {
       for (const lineNumber in comments[filepath]) {
-        compiledComments += `File:\n${filepath}${RangeHelper.truncate(
+        compiledComments += `* ${filepath}${RangeHelper.truncate(
           lineNumber
-        )}\n\n`;
-        const comment = comments[filepath][lineNumber].body;
-        compiledComments += `${comment}\n\n`;
+        )}\n`;
       }
     }
     return compiledComments;

--- a/src/controller/commentController.ts
+++ b/src/controller/commentController.ts
@@ -33,8 +33,10 @@ export class CommentController {
     list = list || [treeItem];
 
     for (const item of list) {
-        const promise = this.commentCacheController.deleteComments(item.uri).catch(() => failedUris.push(item.uri));
-        promises.push(promise);
+      const promise = this.commentCacheController
+        .deleteComments(item.uri)
+        .catch(() => failedUris.push(item.uri));
+      promises.push(promise);
     }
 
     await Promise.all(promises);
@@ -46,18 +48,14 @@ export class CommentController {
    * Creates the comment thread.
    * @returns the created comment.
    */
-  async addComment(){
+  async addComment() {
     const editor = vscode.window.activeTextEditor;
     if (editor) {
       const range = RangeHelper.fromSelection(editor.selections[0]);
       const document = editor.document;
-
       const comment = await this.createComment(document.uri, range);
-      if (comment) {
-        await this.saveCommentToCache(comment);
-      }
+      await this.saveCommentToCache(comment);
       return comment;
-
     } else {
       throw new Error("No active text editor found.");
     }
@@ -118,17 +116,18 @@ export class CommentController {
   dispose() {
     this.controller.dispose();
   }
-  
+
   /**
    * Creates a comment on uri with the selected range.
    * @param uri The file to create the comment on.
    * @param range The range of the comment.
    * @returns The created comment.
    */
-  private async createComment(uri: vscode.Uri, range: vscode.Range){
+  private async createComment(uri: vscode.Uri, range: vscode.Range) {
     const thread = this.controller.createCommentThread(uri, range, []);
-
-    const { filepath, range: rangeString } = await this.getThreadLocation( thread as AssayThread);
+    const { filepath, range: rangeString } = await this.getThreadLocation(
+      thread as AssayThread
+    );
     thread.label = `${filepath}${RangeHelper.truncate(rangeString)}`;
 
     const newComment = new AssayComment(
@@ -200,7 +199,7 @@ export class CommentController {
   private formatCacheComment(comment: AssayComment) {
     return {
       uri: comment.thread.uri,
-      body: comment.body
+      body: comment.body,
     };
   }
 
@@ -217,6 +216,4 @@ export class CommentController {
       this.createComment(uri, range);
     }
   }
-
-  
 }

--- a/src/controller/commentController.ts
+++ b/src/controller/commentController.ts
@@ -15,7 +15,6 @@ export class CommentController {
     private directoryController: DirectoryController
   ) {
     this.controller = vscode.comments.createCommentController(id, label);
-    this.controller.options;
     this.loadCommentsFromCache();
   }
 

--- a/src/controller/directoryController.ts
+++ b/src/controller/directoryController.ts
@@ -16,6 +16,18 @@ export class DirectoryController {
   }
 
   /**
+   * Retrieve the line from uri.
+   * @param uri The uri to retrieve the line from
+   * @param lineNumber the line number to retrieve.
+   * @returns the line, or empty string if none is read.
+   */
+  async getLineFromFile(uri: vscode.Uri, lineNumber: number) {
+    const buffer = await this.readFile(uri);
+    const content = buffer?.toString()?.split("\n");
+    return content?.at(lineNumber) ?? "";
+  }
+
+  /**
    * Gets the root folder stored in config.
    * @returns the root folder in config.
    */

--- a/src/controller/directoryController.ts
+++ b/src/controller/directoryController.ts
@@ -60,7 +60,7 @@ export class DirectoryController {
     const fullPath = uri.fsPath;
     const rootFolder = await this.getRootFolderPath();
     const relativePath = fullPath.replace(rootFolder, "");
-    const [_, guid, version] = relativePath.split(path.sep);  
+    const [_, guid, version] = relativePath.split(path.sep);
     const filepath = relativePath.split(version)[1];
     const versionPath = version
       ? path.join(rootFolder, guid, version)
@@ -112,9 +112,13 @@ export class DirectoryController {
     const failedUris: vscode.Uri[] = [];
 
     for (const item of list) {
-      const thenable = vscode.workspace.fs.delete(item.uri, { recursive: true });
-        const promise = Promise.resolve(thenable).catch(() => failedUris.push(item.uri));
-        promises.push(promise);
+      const thenable = vscode.workspace.fs.delete(item.uri, {
+        recursive: true,
+      });
+      const promise = Promise.resolve(thenable).catch(() =>
+        failedUris.push(item.uri)
+      );
+      promises.push(promise);
     }
 
     await Promise.all(promises);

--- a/src/controller/lintController.ts
+++ b/src/controller/lintController.ts
@@ -1,4 +1,4 @@
-import * as path from "path";  
+import * as path from "path";
 import * as vscode from "vscode";
 
 import { AddonCacheController } from "./addonCacheController";

--- a/src/controller/urlController.ts
+++ b/src/controller/urlController.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import * as path from "path";  
+import * as path from "path";
 import * as vscode from "vscode";
 
 import { AddonController } from "./addonController";
@@ -59,7 +59,7 @@ export class UrlController implements vscode.UriHandler {
     if (!result) {
       return;
     }
-    
+
     const { workspaceFolder, guid, version } = result;
     const versionPath = path.join(workspaceFolder, guid, version);
     this.openWorkspace(versionPath);

--- a/src/controller/urlController.ts
+++ b/src/controller/urlController.ts
@@ -35,15 +35,12 @@ export class UrlController implements vscode.UriHandler {
 
     if (editor && lineNumber) {
       const { endLine } = RangeHelper.splitString(lineNumber);
-      const buffer = await this.directoryController.readFile(uri);
-      const content = buffer?.toString()?.split("\n");
-      const endCharacter = content?.at(endLine)?.length;
+      const endCharacter = (
+        await this.directoryController.getLineFromFile(uri, endLine)
+      )?.length;
 
       // highlight offending lines
-      const lineRange = await RangeHelper.fromString(
-        lineNumber,
-        endCharacter ?? 0
-      );
+      const lineRange = RangeHelper.fromString(lineNumber, endCharacter ?? 0);
       const selection = new vscode.Selection(lineRange.start, lineRange.end);
       editor.selections = [selection];
       // move editor to focus on line(s)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -234,7 +234,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   const copyLinkFromThreadDisposable = vscode.commands.registerCommand(
-    "assay.copyLinkFromThread",
+    "assay.copyLink",
     commentController.copyLinkFromThread,
     commentController
   );
@@ -254,7 +254,7 @@ export async function activate(context: vscode.ExtensionContext) {
     exportCommentDisposable,
     disposeCommentDisposable,
     copyLinkFromThreadDisposable,
-    deleteCommentsFolderDisposable,
+    deleteCommentsFolderDisposable
   );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -233,29 +233,6 @@ export async function activate(context: vscode.ExtensionContext) {
     commentController
   );
 
-  const cancelSaveCommentDisposable = vscode.commands.registerCommand(
-    "assay.cancelSaveComment",
-    commentController.cancelSaveComment,
-    commentController
-  );
-
-  const saveCommentDisposable = vscode.commands.registerCommand(
-    "assay.saveComment",
-    commentController.saveComment
-  );
-
-  const editCommentDisposable = vscode.commands.registerCommand(
-    "assay.editComment",
-    commentController.editComment,
-    commentController
-  );
-
-  const copyLinkFromReplyDisposable = vscode.commands.registerCommand(
-    "assay.copyLinkFromReply",
-    commentController.copyLinkFromReply,
-    commentController
-  );
-
   const copyLinkFromThreadDisposable = vscode.commands.registerCommand(
     "assay.copyLinkFromThread",
     commentController.copyLinkFromThread,
@@ -274,14 +251,10 @@ export async function activate(context: vscode.ExtensionContext) {
     commentController.controller,
     addCommentDisposable,
     deleteCommentDisposable,
-    cancelSaveCommentDisposable,
-    saveCommentDisposable,
-    editCommentDisposable,
     exportCommentDisposable,
     disposeCommentDisposable,
-    copyLinkFromReplyDisposable,
     copyLinkFromThreadDisposable,
-    deleteCommentsFolderDisposable
+    deleteCommentsFolderDisposable,
   );
 }
 

--- a/src/helper/rangeHelper.ts
+++ b/src/helper/rangeHelper.ts
@@ -1,15 +1,21 @@
 import * as vscode from "vscode";
 
 export class RangeHelper {
-  static fromSelection(selection: vscode.Selection) {
-    const startPosition = new vscode.Position(
-      selection.start.line,
-      selection.start.character
-    );
-    const endPosition = new vscode.Position(
-      selection.end.line,
-      selection.end.character
-    );
+  static fromNumber(start: number, end: number, endCharacter = 0) {
+    const startPosition = new vscode.Position(start, 0);
+    const endPosition = new vscode.Position(end, endCharacter);
+    return new vscode.Range(startPosition, endPosition);
+  }
+
+  /**
+   * Creates a range from a vscode Selection.
+   * @param selection the vscode Selection
+   * @param endCharacter The end character, if any
+   * @returns
+   */
+  static fromSelection(selection: vscode.Selection, endCharacter = 0) {
+    const startPosition = new vscode.Position(selection.start.line, 0);
+    const endPosition = new vscode.Position(selection.end.line, endCharacter);
     return new vscode.Range(startPosition, endPosition);
   }
 
@@ -35,13 +41,10 @@ export class RangeHelper {
    * @param endCharacter the character to stop at. Defaults to 0.
    * @returns A VS Code Range
    */
-  static async fromString(
-    str: string,
-    endCharacter: number | undefined = undefined
-  ) {
+  static fromString(str: string, endCharacter = 0) {
     const { startLine, endLine } = RangeHelper.splitString(str);
     const startPosition = new vscode.Position(startLine, 0);
-    const endPosition = new vscode.Position(endLine, endCharacter ?? 0);
+    const endPosition = new vscode.Position(endLine, endCharacter);
     return new vscode.Range(startPosition, endPosition);
   }
 

--- a/src/helper/rangeHelper.ts
+++ b/src/helper/rangeHelper.ts
@@ -1,6 +1,13 @@
 import * as vscode from "vscode";
 
 export class RangeHelper {
+
+  static fromSelection(selection: vscode.Selection){
+    const startPosition = new vscode.Position(selection.start.line, selection.start.character);
+    const endPosition = new vscode.Position(selection.end.line, selection.end.character);
+    return new vscode.Range(startPosition, endPosition);
+  }
+
   /**
    * Splits a string into a start and end of a Range of lines.
    * @param str The string representation of the Range.

--- a/src/helper/rangeHelper.ts
+++ b/src/helper/rangeHelper.ts
@@ -1,10 +1,15 @@
 import * as vscode from "vscode";
 
 export class RangeHelper {
-
-  static fromSelection(selection: vscode.Selection){
-    const startPosition = new vscode.Position(selection.start.line, selection.start.character);
-    const endPosition = new vscode.Position(selection.end.line, selection.end.character);
+  static fromSelection(selection: vscode.Selection) {
+    const startPosition = new vscode.Position(
+      selection.start.line,
+      selection.start.character
+    );
+    const endPosition = new vscode.Position(
+      selection.end.line,
+      selection.end.character
+    );
     return new vscode.Range(startPosition, endPosition);
   }
 

--- a/src/helper/updateHelper.ts
+++ b/src/helper/updateHelper.ts
@@ -1,7 +1,7 @@
 import { spawn } from "child_process";
 import * as fs from "fs";
 import fetch from "node-fetch";
-import * as path from "path";  
+import * as path from "path";
 import * as vscode from "vscode";
 
 export class UpdateHelper {

--- a/src/model/assayComment.ts
+++ b/src/model/assayComment.ts
@@ -1,18 +1,16 @@
 import * as vscode from "vscode";
 
 export class AssayThread implements vscode.CommentThread {
-  canReply: boolean;
   constructor(
     public uri: vscode.Uri,
     public range: vscode.Range,
     public comments: readonly AssayComment[],
+    public canReply: boolean,
     public collapsibleState: vscode.CommentThreadCollapsibleState,
     public dispose: () => void,
     public label?: string | undefined,
     public state?: vscode.CommentThreadState | undefined
-  ) {
-    this.canReply = false;
-  }
+  ) {}
 }
 
 export class AssayComment implements vscode.Comment {
@@ -20,8 +18,6 @@ export class AssayComment implements vscode.Comment {
     public body: string,
     public mode: vscode.CommentMode,
     public author: vscode.CommentAuthorInformation,
-    public thread: AssayThread
-  ) {
-    this.thread.canReply = false;
-  }
+    public thread?: AssayThread
+  ) {}
 }

--- a/src/model/assayComment.ts
+++ b/src/model/assayComment.ts
@@ -1,8 +1,5 @@
 import * as vscode from "vscode";
 
-import { ContextValues } from "../types";
-
-let commentId = 0;
 export class AssayThread implements vscode.CommentThread {
   canReply: boolean;
   constructor(
@@ -12,30 +9,19 @@ export class AssayThread implements vscode.CommentThread {
     public collapsibleState: vscode.CommentThreadCollapsibleState,
     public dispose: () => void,
     public label?: string | undefined,
-    public contextValue?: string | undefined,
     public state?: vscode.CommentThreadState | undefined
   ) {
     this.canReply = false;
   }
 }
 
-export class AssayReply implements vscode.CommentReply {
-  constructor(public thread: AssayThread, public text: string) {}
-}
-
 export class AssayComment implements vscode.Comment {
-  id: number;
-  label: string | undefined;
-  savedBody: vscode.MarkdownString;
   constructor(
-    public body: vscode.MarkdownString,
+    public body: string,
     public mode: vscode.CommentMode,
     public author: vscode.CommentAuthorInformation,
-    public thread: AssayThread,
-    public contextValue: ContextValues
+    public thread: AssayThread
   ) {
-    this.id = ++commentId;
-    this.savedBody = body;
     this.thread.canReply = false;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,6 @@ export type CommentsCache = {
       [filepath: string]: {
         [lineNumber: string]: {
           uri: Uri;
-          body: string;
         };
       };
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,8 +46,6 @@ export type ErrorMessages = {
   };
 };
 
-export type ContextValues = "markForReview" | "comment";
-
 export type CommentsCache = {
   [guid: string]: {
     [version: string]: {
@@ -55,7 +53,6 @@ export type CommentsCache = {
         [lineNumber: string]: {
           uri: Uri;
           body: string;
-          contextValue: ContextValues;
         };
       };
     };
@@ -65,7 +62,6 @@ export type CommentsCache = {
 export type JSONComment = {
   uri: Uri;
   body: string;
-  contextValue: ContextValues;
 };
 
 export type JSONReview = {

--- a/test/suite/controller/commentCacheController.test.ts
+++ b/test/suite/controller/commentCacheController.test.ts
@@ -33,7 +33,7 @@ describe("commentCacheController.ts", () => {
       assayCacheStub.getFromCache.resolves({
         "/test-filepath": {
           "#L1": {
-            "body": "test-comment"
+            "body": "Marked for review."
           },
         },
       });
@@ -41,7 +41,6 @@ describe("commentCacheController.ts", () => {
       const result = await commentCacheController.compileComments("guid", "version");
       expect(result).to.contain("test-filepath");
       expect(result).to.contain("#L2");
-      expect(result).to.contain("test-comment");
     });
   });
 

--- a/test/suite/controller/commentCacheController.test.ts
+++ b/test/suite/controller/commentCacheController.test.ts
@@ -32,9 +32,7 @@ describe("commentCacheController.ts", () => {
     it("should return the compiled comments.", async () => {
       assayCacheStub.getFromCache.resolves({
         "/test-filepath": {
-          "#L1": {
-            "body": "Marked for review."
-          },
+          "#L1": {},
         },
       });
 
@@ -83,9 +81,7 @@ describe("commentCacheController.ts", () => {
     it("should open an information message.", async () => {
       assayCacheStub.getFromCache.resolves({
         "/test-filepath": {
-          "#L1": {
-            "body": "test-comment"
-          },
+          "#L1": {},
         },
     });
 
@@ -113,7 +109,6 @@ describe("commentCacheController.ts", () => {
           "test-version-1" : {
             "filepath-one": {
               "#L1": {
-                "body": "test-comment",
                 "uri": vscode.Uri.file(
                   "test-root-folder-path/test-guid/test-version-1/filepath-one"
                 )
@@ -123,7 +118,6 @@ describe("commentCacheController.ts", () => {
           "test-version-2" : {
             "filepath-two": {
               "#L1": {
-                "body": "test-comment",
                 "uri": vscode.Uri.file(
                   "test-root-folder-path/test-guid/test-version-2/filepath-two"
                 )
@@ -150,7 +144,6 @@ describe("commentCacheController.ts", () => {
             "test-version" : {
               "test-filepath": {
                 "#L1": {
-                  "body": "test-comment",
                   "uri": vscode.Uri.file(
                     "test-root-folder-path/test-guid/test-version/test-filepath"
                   )

--- a/test/suite/controller/commentController.test.ts
+++ b/test/suite/controller/commentController.test.ts
@@ -9,8 +9,7 @@ import * as vscode from "vscode";
 import { CommentCacheController } from "../../../src/controller/commentCacheController";
 import { CommentController } from "../../../src/controller/commentController";
 import { DirectoryController } from "../../../src/controller/directoryController";
-import { AssayReply, AssayThread } from "../../../src/model/assayComment";
-import { ContextValues } from "../../../src/types";
+import { AssayThread } from "../../../src/model/assayComment";
 
 let commentCacheControllerStub: sinon.SinonStubbedInstance<CommentCacheController>, directoryControllerStub: sinon.SinonStubbedInstance<DirectoryController>;
 
@@ -21,8 +20,7 @@ const cmt = {
   uri: vscode.Uri.file(
     "test-root/test-guid/test-version/test-filepath"
   ),
-  body: "test-comment",
-  contextValue: "comment" as ContextValues
+  body: "test-comment"
 };
 
 const pos = new vscode.Position(1, 0);
@@ -59,153 +57,21 @@ describe("CommentController.ts", () => {
     }
   });
 
-  describe("addComment", async () => {
-    it("should create a comment & thread from non-empty reply and save the comment to cache.", async () => {
-        const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
-        const thread = cmtController.controller.createCommentThread(cmt.uri, rng, []) as AssayThread;
-        const reply = new AssayReply(thread, cmt.body);
-
-        // was created, and correctly
-        expect(thread.comments.length).to.be.equal(0);
-        await cmtController.addComment(reply);
-        expect(thread.comments.length).to.be.equal(1);
-
-        const comment = thread.comments[0];
-        expect(comment.body.value).to.be.equal(cmt.body);
-        expect(comment.contextValue).to.be.equal(cmt.contextValue);
-        expect(comment.thread).to.be.equal(thread);
-        expect(comment.thread.comments.length).to.be.equal(1);
-        expect(comment.thread.comments[0]).to.be.equal(comment);
-
-        // was added to cache
-        expect(commentCacheControllerStub.saveCommentToCache.called).to.be.true;
-    });
-
-    it("should create a markForReview & comment thread from an empty reply.", async () => {
-        const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
-        const thread = cmtController.controller.createCommentThread(cmt.uri, rng, []) as AssayThread;
-        const reply = new AssayReply(thread, "");
-
-        // was created
-        expect(thread.comments.length).to.be.equal(0);
-        await cmtController.addComment(reply);
-        expect(thread.comments.length).to.be.equal(1);  
-        expect(thread.comments[0].body.value).to.be.equal("Marked for review.");
-        expect(thread.comments[0].contextValue).to.be.equal("markForReview");
-
-        // was added to cache
-        expect(commentCacheControllerStub.saveCommentToCache.called).to.be.true;
-    });
-  });
-
-  describe("saveComment", () => {
-    it("should update a comment's body to the new string both in comment and in cache.", async () => {
-        const newBody = new vscode.MarkdownString("Hello, world!");
-        const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
-        const thread = cmtController.controller.createCommentThread(cmt.uri, rng, []) as AssayThread;
-        const reply = new AssayReply(thread, cmt.body);
-        const comment = await cmtController.addComment(reply);
-
-        expect(comment.body.value).to.be.equal(cmt.body);
-        comment.body = newBody;
-        await cmtController.saveComment(comment);
-        expect(comment.body.value).to.be.equal(newBody.value);
-        expect(comment.contextValue).to.be.equal("comment");
-        
-        // was added to cache
-        expect(commentCacheControllerStub.saveCommentToCache.called).to.be.true;
-    });
-    it("should take an empty string and populate it as marked.", async () => {
-        const newBody = new vscode.MarkdownString("");
-        const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
-        const thread = cmtController.controller.createCommentThread(cmt.uri, rng, []) as AssayThread;
-        const reply = new AssayReply(thread, cmt.body);
-        const comment = await cmtController.addComment(reply);
-
-
-        expect(comment.body.value).to.be.equal(cmt.body);
-        comment.body = newBody;
-        await cmtController.saveComment(comment);
-        expect(comment.body.value).to.be.equal("Marked for review.");
-        expect(comment.contextValue).to.be.equal("markForReview");
-        
-        // was added to cache
-        expect(commentCacheControllerStub.saveCommentToCache.called).to.be.true;
-    });
-  });
-
-  describe("cancelSaveComment", () => {
-    it("should retain its original body text.", async () => {
-        const newBody = new vscode.MarkdownString("Hello, world!");
-        const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
-        const thread = cmtController.controller.createCommentThread(cmt.uri, rng, []) as AssayThread;
-        const reply = new AssayReply(thread, cmt.body);
-        const comment = await cmtController.addComment(reply);
-
-        expect(comment.body.value).to.be.equal(cmt.body);
-        comment.body = newBody;
-        await cmtController.cancelSaveComment(comment);
-        expect(comment.body.value).to.be.equal(cmt.body);
-        expect(comment.contextValue).to.be.equal("comment");
-    });
-  });
-
   describe("deleteThread", () => {
-    it("should delete the comment thread from a controller and its comments from cache.", async () => {
-        const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
+    // it("should delete the comment thread from a controller and its comments from cache.", async () => {
+    //     const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
 
-        const thread = cmtController.controller.createCommentThread(cmt.uri, rng, []) as AssayThread;
-        const disposeStub = sinon.stub(thread, "dispose");
-        const reply = new AssayReply(thread, cmt.body);         
-        const comment = await cmtController.addComment(reply);
+    //     const thread = cmtController.controller.createCommentThread(cmt.uri, rng, []) as AssayThread;
+    //     const disposeStub = sinon.stub(thread, "dispose");
+    //     const reply = new AssayReply(thread, cmt.body);         
+    //     const comment = await cmtController.addComment(reply);
                
-        await cmtController.deleteThread(comment.thread);
-        expect(disposeStub.calledOnce).to.be.true;
+    //     await cmtController.deleteThread(comment.thread);
+    //     expect(disposeStub.calledOnce).to.be.true;
 
-        // was removed from cache
-        expect(commentCacheControllerStub.deleteCommentFromCache.called).to.be.true;
-    });
-  });
-
-  describe("editComment", () => {
-    it("should set a comment to edit mode.", async () => {
-        const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
-        const thread = cmtController.controller.createCommentThread(cmt.uri, rng, []) as AssayThread;
-        const reply = new AssayReply(thread, cmt.body);
-        const comment = await cmtController.addComment(reply);
-
-        expect(comment.mode).to.be.equal(vscode.CommentMode.Preview);
-        expect(comment.body.value).to.be.equal(cmt.body);
-        cmtController.editComment(thread);
-        expect(comment.body.value).to.be.equal(cmt.body);
-        expect(comment.mode).to.be.equal(vscode.CommentMode.Editing);
-    });
-  
-    it("should clear the body if a markForReview comment.", async () => {
-        const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
-        const thread = cmtController.controller.createCommentThread(cmt.uri, rng, []) as AssayThread;
-        const reply = new AssayReply(thread, "");
-        const comment = await cmtController.addComment(reply);
-
-        expect(comment.mode).to.be.equal(vscode.CommentMode.Preview);
-        expect(comment.body.value).to.be.equal("Marked for review.");
-        cmtController.editComment(thread);
-        expect(comment.body.value).to.be.equal("");
-        expect(comment.mode).to.be.equal(vscode.CommentMode.Editing);      
-    });
-  });
-
-  describe("copyLinkFromReply", () => {
-    it("should call copyLinkFromThread with the reply's thread", () => {
-      const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
-      const thread = cmtController.controller.createCommentThread(cmt.uri, rng, []) as AssayThread;
-      const reply = new AssayReply(thread, cmt.body);
-      const copyLinkFromThreadStub = sinon.stub(cmtController, 'copyLinkFromThread');
-
-      cmtController.copyLinkFromReply(reply);
-
-      expect(copyLinkFromThreadStub.calledOnceWith(thread)).to.be.true;
-    });
+    //     // was removed from cache
+    //     expect(commentCacheControllerStub.deleteCommentFromCache.called).to.be.true;
+    // });
   });
 
   describe("copyLinkFromThread", () => {

--- a/test/suite/controller/commentController.test.ts
+++ b/test/suite/controller/commentController.test.ts
@@ -60,13 +60,13 @@ describe("CommentController.ts", () => {
     it("should delete the comment thread from a controller and its comments from cache.", async () => {
         const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
 
-        // const comment = await cmtController["createComment"](cmt.uri, rng);
-        // const disposeStub = sinon.stub(comment.thread, "dispose");
-        // await cmtController.deleteThread(comment.thread);
-        // expect(disposeStub.calledOnce).to.be.true;
+        const comment = await cmtController["createComment"](cmt.uri, rng);
+        const disposeStub = sinon.stub(comment.thread as AssayThread, "dispose");
+        await cmtController.deleteThread(comment.thread as AssayThread);
+        expect(disposeStub.calledOnce).to.be.true;
 
-        // // was removed from cache
-        // expect(commentCacheControllerStub.deleteCommentFromCache.called).to.be.true;
+        // was removed from cache
+        expect(commentCacheControllerStub.deleteCommentFromCache.called).to.be.true;
     });
   });
 

--- a/test/suite/controller/commentController.test.ts
+++ b/test/suite/controller/commentController.test.ts
@@ -56,6 +56,24 @@ describe("CommentController.ts", () => {
     }
   });
 
+  describe("addComment", () => {
+
+    it("should create a comment.", async () => {
+       sinon.stub(vscode.window, 'activeTextEditor').value({
+        document: {
+          uri: 'test-uri',
+          lineAt: sinon.stub().returns({ text: 'Code Line' }),
+        },
+        selections: [{ start: { line: 0, character: 0 }, end: { line: 0, character: 10 } }],
+      });
+      const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
+      const result = await cmtController.addComment();
+      expect(commentCacheControllerStub.saveCommentToCache.called).to.be.true;
+      expect(result).to.exist;
+
+    });
+  });
+
   describe("deleteThread", () => {
     it("should delete the comment thread from a controller and its comments from cache.", async () => {
         const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);

--- a/test/suite/controller/commentController.test.ts
+++ b/test/suite/controller/commentController.test.ts
@@ -19,8 +19,7 @@ const storagePath = path.resolve(workspaceFolder, ".test_assay");
 const cmt = {
   uri: vscode.Uri.file(
     "test-root/test-guid/test-version/test-filepath"
-  ),
-  body: "test-comment"
+  )
 };
 
 const pos = new vscode.Position(1, 0);
@@ -61,13 +60,13 @@ describe("CommentController.ts", () => {
     it("should delete the comment thread from a controller and its comments from cache.", async () => {
         const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
 
-        const comment = await cmtController["createComment"](cmt.uri, rng);
-        const disposeStub = sinon.stub(comment.thread, "dispose");
-        await cmtController.deleteThread(comment.thread);
-        expect(disposeStub.calledOnce).to.be.true;
+        // const comment = await cmtController["createComment"](cmt.uri, rng);
+        // const disposeStub = sinon.stub(comment.thread, "dispose");
+        // await cmtController.deleteThread(comment.thread);
+        // expect(disposeStub.calledOnce).to.be.true;
 
-        // was removed from cache
-        expect(commentCacheControllerStub.deleteCommentFromCache.called).to.be.true;
+        // // was removed from cache
+        // expect(commentCacheControllerStub.deleteCommentFromCache.called).to.be.true;
     });
   });
 

--- a/test/suite/controller/commentController.test.ts
+++ b/test/suite/controller/commentController.test.ts
@@ -58,20 +58,17 @@ describe("CommentController.ts", () => {
   });
 
   describe("deleteThread", () => {
-    // it("should delete the comment thread from a controller and its comments from cache.", async () => {
-    //     const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
+    it("should delete the comment thread from a controller and its comments from cache.", async () => {
+        const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
 
-    //     const thread = cmtController.controller.createCommentThread(cmt.uri, rng, []) as AssayThread;
-    //     const disposeStub = sinon.stub(thread, "dispose");
-    //     const reply = new AssayReply(thread, cmt.body);         
-    //     const comment = await cmtController.addComment(reply);
-               
-    //     await cmtController.deleteThread(comment.thread);
-    //     expect(disposeStub.calledOnce).to.be.true;
+        const comment = await cmtController["createComment"](cmt.uri, rng);
+        const disposeStub = sinon.stub(comment.thread, "dispose");
+        await cmtController.deleteThread(comment.thread);
+        expect(disposeStub.calledOnce).to.be.true;
 
-    //     // was removed from cache
-    //     expect(commentCacheControllerStub.deleteCommentFromCache.called).to.be.true;
-    // });
+        // was removed from cache
+        expect(commentCacheControllerStub.deleteCommentFromCache.called).to.be.true;
+    });
   });
 
   describe("copyLinkFromThread", () => {

--- a/test/suite/controller/directoryController.test.ts
+++ b/test/suite/controller/directoryController.test.ts
@@ -14,6 +14,19 @@ describe("directoryController.ts", async () => {
     sinon.restore();
   });
 
+  describe("getLineFromFile()", async () => {
+
+    it("should fetch the desired line from the given line number and uri", async () => {
+        const uri = vscode.Uri.file('/test/path');
+        const buffer = Buffer.from("Line 0\nLine 1\nLine 2");
+        const directoryController = new DirectoryController();
+        const readFileStub = sinon.stub(directoryController, 'readFile').resolves(buffer);
+        const result = await directoryController.getLineFromFile(uri, 2);
+        expect(readFileStub.called).to.be.true;
+        expect(result).to.equal("Line 2");
+    });
+  });
+
   describe("getRootFolderPath()", async () => {
     it("should return the folder that is already set.", async () => {
         const configStub = sinon.stub(vscode.workspace, "getConfiguration");

--- a/test/suite/helper/rangeHelper.ts
+++ b/test/suite/helper/rangeHelper.ts
@@ -17,6 +17,28 @@ describe("rangeHelper.ts", () => {
         sinon.restore();
     });
 
+    describe('fromNumber()', function() {
+        it('should create a Range from numbers.', function() {
+            const start = 5;
+            const end = 10;
+            const endCharacter = 15;
+            const range = RangeHelper.fromNumber(start, end, endCharacter);
+            expect(range.start).to.deep.equal(new vscode.Position(start, 0));
+            expect(range.end).to.deep.equal(new vscode.Position(end, endCharacter));
+        });
+      });
+    
+      describe('fromSelection()', function() {
+        it('should create a Range from a vscode Selection.', function() {
+          const selection = new vscode.Selection(5, 10, 15, 20);
+          const endCharacter = 15;
+    
+          const range = RangeHelper.fromSelection(selection, endCharacter);
+          expect(range.start).to.deep.equal(new vscode.Position(selection.start.line, 0));
+          expect(range.end).to.deep.equal(new vscode.Position(selection.end.line, endCharacter));
+        });
+      });
+
     describe("toString()", () => {
     it("should convert a single-line range correctly.", async () => {
         const range = RangeHelper.toString(rng);


### PR DESCRIPTION
Closes #90 

**Changes**
- Removes the user's ability to make comments and changes the export to include only a list of selected lines.
- Fixed some visual errors on marking lines for review relating to how they're initialized
- Removed the stored values `body`, `contextValue`

![ScreenRecording2024-07-31at10 23 47AM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/54f10f75-ef16-4c20-a78d-0e598e71ed86)
