### PR TITLE
Set `bcompare` as the default diff tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "assay.diffTool": {
           "type": "string",
           "description": "Command to launch external tool to diff add-ons.",
-          "default": ""
+          "default": "bcompare"
         },
         "assay.deleteCommentsOnExport": {
           "type": "string",


### PR DESCRIPTION
Fixes #94

---

I verified on macOS by installing the "command line tools" in Beyond Compare.