### PR TITLE
Allow Version Files to be Editable by Reviewers

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
       "properties": {
         "assay.rootFolder": {
           "type": "string",
-          "description": "The directory where add-ons are saved. Using the 'Files: Readonly Include' setting, Assay will set the new directory to readonly and release the original.",
+          "description": "The directory where add-ons are saved.",
           "default": ""
         },
         "assay.diffTool": {

--- a/src/controller/addonCacheController.ts
+++ b/src/controller/addonCacheController.ts
@@ -29,4 +29,18 @@ export class AddonCacheController {
   async getAddonFromCache(keys: string[]) {
     return await this.cache.getFromCache(keys);
   }
+
+  /**
+   * Check if guid, version is dirtied. 
+   */
+  async isDirty(guid: string, version: string){
+    return await this.cache.getFromCache([guid, version, "isDirty"]);
+  }
+
+  /**
+   * Set guid, version to dirtied.
+   */
+  async setDirty(guid: string, version: string){
+    this.cache.addToCache([guid, version, "isDirty"], true);
+  }
 }

--- a/src/controller/addonCacheController.ts
+++ b/src/controller/addonCacheController.ts
@@ -33,7 +33,7 @@ export class AddonCacheController {
   /**
    * Check if guid, version is dirtied.
    */
-  async isDirty(guid: string, version: string) {
+  async isVersionDirty(guid: string, version: string) {
     return await this.cache.getFromCache([guid, version, "isDirty"]);
   }
 

--- a/src/controller/addonCacheController.ts
+++ b/src/controller/addonCacheController.ts
@@ -31,16 +31,16 @@ export class AddonCacheController {
   }
 
   /**
-   * Check if guid, version is dirtied. 
+   * Check if guid, version is dirtied.
    */
-  async isDirty(guid: string, version: string){
+  async isDirty(guid: string, version: string) {
     return await this.cache.getFromCache([guid, version, "isDirty"]);
   }
 
   /**
    * Set guid, version to dirtied.
    */
-  async setDirty(guid: string, version: string){
+  async setVersionAsDirty(guid: string, version: string) {
     this.cache.addToCache([guid, version, "isDirty"], true);
   }
 }

--- a/src/controller/addonController.ts
+++ b/src/controller/addonController.ts
@@ -93,7 +93,7 @@ export class AddonController {
         version: version,
         fileID: addonFileID,
         id: addonID,
-        isDirty: false
+        isDirty: false,
       });
 
       const writeStream = await this.downloadAddon(

--- a/src/controller/addonController.ts
+++ b/src/controller/addonController.ts
@@ -93,6 +93,7 @@ export class AddonController {
         version: version,
         fileID: addonFileID,
         id: addonID,
+        isDirty: false
       });
 
       const writeStream = await this.downloadAddon(
@@ -107,6 +108,8 @@ export class AddonController {
       );
 
       this.sidebarController.refresh();
+
+      //TODO: lint workspace
 
       return { workspaceFolder, guid, version };
     } catch (error) {

--- a/src/controller/addonController.ts
+++ b/src/controller/addonController.ts
@@ -109,8 +109,6 @@ export class AddonController {
 
       this.sidebarController.refresh();
 
-      //TODO: lint workspace
-
       return { workspaceFolder, guid, version };
     } catch (error) {
       console.error(error);

--- a/src/controller/directoryController.ts
+++ b/src/controller/directoryController.ts
@@ -6,7 +6,6 @@ import { AddonTreeItem } from "../model/sidebarTreeDataProvider";
 import { RootView } from "../views/rootView";
 
 export class DirectoryController {
-
   /**
    * Retrieve the line from uri.
    * @param uri The uri to retrieve the line from

--- a/src/controller/directoryController.ts
+++ b/src/controller/directoryController.ts
@@ -3,17 +3,9 @@ import * as path from "path";
 import * as vscode from "vscode";
 
 import { AddonTreeItem } from "../model/sidebarTreeDataProvider";
-import { FilesReadonlyIncludeConfig } from "../types";
 import { RootView } from "../views/rootView";
 
 export class DirectoryController {
-  private cachedRootFolder: string | undefined;
-
-  constructor() {
-    const assayConfig = vscode.workspace.getConfiguration("assay");
-    const rootFolder = assayConfig.get<string>("rootFolder");
-    this.setCachedRootFolder(rootFolder);
-  }
 
   /**
    * Retrieve the line from uri.
@@ -42,25 +34,9 @@ export class DirectoryController {
         throw new Error("No root folder selected");
       }
       await this.storeRootFolderSetting(newRootFolder);
-      this.setRootToReadonly();
       return newRootFolder;
     }
     return rootFolder;
-  }
-
-  /**
-   * Whenever rootFolder or readonlyInclude is modified, ensures that:
-   * 1) the old root folder is removed from readonly, and
-   * 2) the new one is added.
-   * @param event The configuration change event.
-   */
-  async handleRootConfigurationChange(event: vscode.ConfigurationChangeEvent) {
-    if (
-      event.affectsConfiguration("assay.rootFolder") ||
-      event.affectsConfiguration("files.readonlyInclude")
-    ) {
-      await this.setRootToReadonly();
-    }
   }
 
   /**
@@ -138,33 +114,6 @@ export class DirectoryController {
   }
 
   /**
-   * Sets the root to read-only.
-   */
-  private async setRootToReadonly() {
-    const assayConfig = vscode.workspace.getConfiguration("assay");
-    const rootFolder = assayConfig.get<string>("rootFolder");
-
-    const fileConfig = vscode.workspace.getConfiguration("files");
-    const readOnlyFiles = fileConfig.get(
-      "readonlyInclude"
-    ) as FilesReadonlyIncludeConfig;
-
-    // remove the cachedRootFolder's readonly property.
-    const globInitialFolder = `${this.cachedRootFolder}/**`;
-    if (globInitialFolder in readOnlyFiles) {
-      readOnlyFiles[globInitialFolder] = false;
-    }
-    await fileConfig.update(
-      "readonlyInclude",
-      { ...readOnlyFiles, [`${rootFolder}/**`]: true },
-      vscode.ConfigurationTarget.Global
-    );
-
-    // update the cached root folder here and on launch
-    this.setCachedRootFolder(rootFolder);
-  }
-
-  /**
    * Updates the config's rootFolder.
    * @param rootFolder The location of the root folder.
    */
@@ -175,13 +124,5 @@ export class DirectoryController {
       rootFolder,
       vscode.ConfigurationTarget.Global
     );
-  }
-
-  /**
-   * Updates the cached root folder.
-   * @param filepath the location of the root folder.
-   */
-  private setCachedRootFolder(filepath: string | undefined) {
-    this.cachedRootFolder = filepath;
   }
 }

--- a/src/controller/lintController.ts
+++ b/src/controller/lintController.ts
@@ -25,10 +25,11 @@ export class LintController {
    * Tracks currently dirtied files.
    * @param event A vscode event describing a document change.
    */
-  addDirty(event: vscode.TextDocumentChangeEvent) {
+  toggleDirty(event: vscode.TextDocumentChangeEvent) {
     const document = event.document;
     if (document.isDirty) {
       this.dirtyFiles.add(document.uri.fsPath);
+      // if the change was an empty undo, it was reset to its natural state
     } else if (event.reason && event.contentChanges) {
       this.dirtyFiles.delete(document.uri.fsPath);
     }
@@ -45,7 +46,6 @@ export class LintController {
    * Clears existing lints if a document is saved when it was dirtied.
    */
   clearLintsOnDirty(document: vscode.TextDocument) {
-    console.log(this.dirtyFiles);
     if (this.dirtyFiles.has(document.uri.fsPath)) {
       this.clearLints(document.uri);
     }
@@ -100,7 +100,7 @@ export class LintController {
       return;
     }
 
-    if (await this.addonCacheController.isDirty(guid, version)) {
+    if (await this.addonCacheController.isVersionDirty(guid, version)) {
       return;
     }
 

--- a/src/controller/lintController.ts
+++ b/src/controller/lintController.ts
@@ -17,6 +17,15 @@ export class LintController {
   ) {}
 
   /**
+   * Clears existing lints if a document is saved.
+   */
+  async clearLintsOnDirty(document: vscode.TextDocument){
+    this.diagnosticCollection.clear();
+    const { guid, version } = await this.directoryController.splitUri(document.uri);
+    this.addonCacheController.setDirty(guid, version);
+  }
+
+  /**
    * Lints the current workspace.
    */
   async lintWorkspace() {
@@ -27,7 +36,12 @@ export class LintController {
 
     const { versionPath, guid, version } =
       await this.directoryController.splitUri(workspace.uri);
+      
     if (!versionPath) {
+      return;
+    }
+
+    if(await this.addonCacheController.isDirty(guid, version)){
       return;
     }
 

--- a/src/controller/lintController.ts
+++ b/src/controller/lintController.ts
@@ -61,7 +61,7 @@ export class LintController {
   clearLintsOnDelete(event: vscode.FileDeleteEvent) {
     let warnUser = true;
     for (const file of event.files) {
-      this.clearLints(vscode.Uri.parse(file.fsPath, warnUser));
+      this.clearLints(vscode.Uri.parse(file.fsPath), warnUser);
       warnUser = false;
     }
   }

--- a/src/controller/urlController.ts
+++ b/src/controller/urlController.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 
 import { AddonController } from "./addonController";
 import { DirectoryController } from "./directoryController";
+import { LintController } from "./lintController";
 import { RangeHelper } from "../helper/rangeHelper";
 import { AddonTreeItem } from "../model/sidebarTreeDataProvider";
 
@@ -11,7 +12,8 @@ export class UrlController implements vscode.UriHandler {
   constructor(
     private context: vscode.ExtensionContext,
     private addonController: AddonController,
-    private directoryController: DirectoryController
+    private directoryController: DirectoryController,
+    private lintController: LintController
   ) {}
 
   /**
@@ -142,12 +144,16 @@ export class UrlController implements vscode.UriHandler {
       vscode.commands
         .executeCommand("vscode.openFolder", versionUri)
         .then(() => {
-          this.revealFile(vscode.Uri.file(filePath), lineNumber);
+          this.revealFile(vscode.Uri.file(filePath), lineNumber).then(() => {
+            this.lintController.lintWorkspace();
+          });
         });
     }
     // If user already has the version folder opened, open the manifest.json
     else if (workspace[0].uri.fsPath === versionUri.fsPath) {
-      this.revealFile(vscode.Uri.file(filePath), lineNumber);
+      this.revealFile(vscode.Uri.file(filePath), lineNumber).then(() => {
+        this.lintController.lintWorkspace();
+      });
     }
     // Otherwise, store the filePath (since the extension must restart) to open on launch.
     else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -117,12 +117,6 @@ export async function activate(context: vscode.ExtensionContext) {
     urlController
   );
 
-  const handleRootConfigurationChangeDisposable =
-    vscode.workspace.onDidChangeConfiguration(
-      directoryController.handleRootConfigurationChange,
-      directoryController
-    );
-
   context.subscriptions.push(
     UriHandlerDisposable,
     reviewDisposable,
@@ -136,8 +130,7 @@ export async function activate(context: vscode.ExtensionContext) {
     sidebarDeleteDisposable,
     viewAddonDisposable,
     diffDisposable,
-    assayUpdaterDisposable,
-    handleRootConfigurationChangeDisposable
+    assayUpdaterDisposable
   );
 
   await vscode.commands.executeCommand(
@@ -201,6 +194,11 @@ export async function activate(context: vscode.ExtensionContext) {
   urlController.openCachedFile();
   lintController.lintWorkspace();
 
+  const clearLintDisposable = vscode.workspace.onDidSaveTextDocument(
+    lintController.clearLintsOnDirty,
+    lintController
+  );
+
   const fileDecorationProviderDisposable =
     vscode.window.registerFileDecorationProvider(fileDecorationProvider);
 
@@ -254,7 +252,8 @@ export async function activate(context: vscode.ExtensionContext) {
     exportCommentDisposable,
     disposeCommentDisposable,
     copyLinkFromThreadDisposable,
-    deleteCommentsFolderDisposable
+    deleteCommentsFolderDisposable,
+    clearLintDisposable
   );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -208,10 +208,10 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   const addDirtyOnChangeDisposable = vscode.workspace.onDidChangeTextDocument(
-    lintController.addDirty,
+    lintController.toggleDirty,
     lintController
   );
-  
+
   const removeDirtyDisposable = vscode.workspace.onDidCloseTextDocument(
     lintController.removeDirty,
     lintController

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,6 @@ import { UpdateHelper } from "./helper/updateHelper";
 import { AssayCache } from "./model/assayCache";
 import { CustomFileDecorationProvider } from "./model/fileDecorationProvider";
 import { AddonTreeItem } from "./model/sidebarTreeDataProvider";
-import { LintView } from "./views/lintView";
 import { WelcomeView } from "./views/welcomeView";
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -48,7 +47,8 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  const diagnosticCollection = vscode.languages.createDiagnosticCollection("addons-linter");
+  const diagnosticCollection =
+    vscode.languages.createDiagnosticCollection("addons-linter");
 
   const lintController = new LintController(
     diagnosticCollection,
@@ -183,7 +183,6 @@ export async function activate(context: vscode.ExtensionContext) {
     commentCacheController.fileHasComment
   );
 
-
   const commentController = new CommentController(
     "assay-comments",
     "Assay",
@@ -200,6 +199,21 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const clearLintDisposable = vscode.workspace.onDidSaveTextDocument(
     lintController.clearLintsOnDirty,
+    lintController
+  );
+
+  const addDirtyOnDeleteDisposable = vscode.workspace.onDidDeleteFiles(
+    lintController.clearLintsOnDelete,
+    lintController
+  );
+
+  const addDirtyOnChangeDisposable = vscode.workspace.onDidChangeTextDocument(
+    lintController.addDirty,
+    lintController
+  );
+  
+  const removeDirtyDisposable = vscode.workspace.onDidCloseTextDocument(
+    lintController.removeDirty,
     lintController
   );
 
@@ -247,10 +261,6 @@ export async function activate(context: vscode.ExtensionContext) {
     commentController
   );
 
-  const addDirtyDisposable = vscode.workspace.onDidChangeTextDocument(lintController.addDirty, lintController);
-  const removeDirtyDisposable = vscode.workspace.onDidCloseTextDocument(lintController.removeDirty, lintController);
-
-
   context.subscriptions.push(
     updateStatusBarController,
     fileDecorationProviderDisposable,
@@ -262,7 +272,8 @@ export async function activate(context: vscode.ExtensionContext) {
     copyLinkFromThreadDisposable,
     deleteCommentsFolderDisposable,
     clearLintDisposable,
-    addDirtyDisposable,
+    addDirtyOnDeleteDisposable,
+    addDirtyOnChangeDisposable,
     removeDirtyDisposable
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export type JSONReview = {
   version: string;
   fileID: string;
   id: string;
+  isDirty: boolean;
 };
 
 export type ThreadLocation = {
@@ -76,10 +77,6 @@ export type ThreadLocation = {
   version: string;
   filepath: string;
   range: string;
-};
-
-export type FilesReadonlyIncludeConfig = {
-  [key: string]: boolean;
 };
 
 export type MessageType = "error" | "notice" | "warning";

--- a/src/views/lintView.ts
+++ b/src/views/lintView.ts
@@ -1,0 +1,14 @@
+import * as vscode from "vscode";
+
+export class LintView {
+
+  /**
+   * Warn the user that saving will remove the lints. 
+   */
+  static async warnOnSave(){
+    await vscode.window.showInformationMessage(
+      '(Assay) Version modified. Lints cleared.'
+    );
+  }
+
+}

--- a/src/views/lintView.ts
+++ b/src/views/lintView.ts
@@ -1,14 +1,12 @@
 import * as vscode from "vscode";
 
 export class LintView {
-
   /**
-   * Warn the user that saving will remove the lints. 
+   * Warn the user that saving will remove the lints.
    */
-  static async warnOnSave(){
+  static async warnOnSave() {
     await vscode.window.showInformationMessage(
-      '(Assay) Version modified. Lints cleared.'
+      "(Assay) Version modified. Lints cleared."
     );
   }
-
 }

--- a/test/suite/controller/addonCacheController.test.ts
+++ b/test/suite/controller/addonCacheController.test.ts
@@ -18,6 +18,21 @@ describe("addonCacheController.ts", () => {
     addonCacheController = new AddonCacheController(assayCacheStub);
   });
 
+  describe("isVersionDirty()", () => {
+    it("should return the result of whether the version is dirty from storage.", () => {
+      addonCacheController.isVersionDirty("test-guid", "version");
+      expect(assayCacheStub.getFromCache.calledWith(["test-guid", "version", "isDirty"])).to.be.true;
+    });
+  });
+
+  describe("setVersionAsDirty()", () => {
+    it("should set the versions dirty state to true.", () => {
+      addonCacheController.setVersionAsDirty("test-guid", "version");
+      expect(assayCacheStub.addToCache.calledWith(["test-guid", "version", "isDirty"], true)).to.be.true;
+    });
+  });
+
+
   describe("addAddonToCache()", () => {
     it("should add a new addon's information to cache.", async () => {
 

--- a/test/suite/controller/addonCacheController.test.ts
+++ b/test/suite/controller/addonCacheController.test.ts
@@ -27,7 +27,8 @@ describe("addonCacheController.ts", () => {
             reviewUrl: "url",
             version: "version",
             fileID: "file-id",
-            id: "id"
+            id: "id",
+            isDirty: false
         };
 
         await addonCacheController.addAddonToCache("test-guid", rawReviewMeta);
@@ -42,28 +43,29 @@ describe("addonCacheController.ts", () => {
     });
 
     it("should update an addon's information in cache.", async () => {
-      assayCacheStub.getFromCache.resolves({
-        reviewUrl: "url",
-        version: "version",
-        fileIDs: {"version": "file-id"},
-        id: "id"
-    });
+        assayCacheStub.getFromCache.resolves({
+          reviewUrl: "url",
+          version: "version",
+          fileIDs: {"version": "file-id"},
+          id: "id"
+      });
 
-        const rawReviewMeta = {
-            reviewUrl: "url",
-            version: "version-two",
-            fileID: "file-id-two",
-            id: "id"
-        };
+      const rawReviewMeta = {
+          reviewUrl: "url",
+          version: "version-two",
+          fileID: "file-id-two",
+          id: "id",
+          isDirty: false
+      };
 
-        await addonCacheController.addAddonToCache("test-guid", rawReviewMeta);
+      await addonCacheController.addAddonToCache("test-guid", rawReviewMeta);
 
-        expect(assayCacheStub.addToCache.calledWith(["test-guid"], {
-            reviewUrl: "url",
-            version: "version",
-            fileIDs: {"version": "file-id", "version-two": "file-id-two"},
-            id: "id"
-        }));
+      expect(assayCacheStub.addToCache.calledWith(["test-guid"], {
+          reviewUrl: "url",
+          version: "version",
+          fileIDs: {"version": "file-id", "version-two": "file-id-two"},
+          id: "id"
+      }));
     });
 
   });

--- a/test/suite/controller/directoryController.test.ts
+++ b/test/suite/controller/directoryController.test.ts
@@ -137,43 +137,4 @@ describe("directoryController.ts", async () => {
     });
   });
 
-
-  describe("handleRootConfigurationChange()", async () => {
-    const configStub = sinon.stub(vscode.workspace, "getConfiguration");
-    const assayConfig = {
-        update: sinon.stub(),
-        get: () => {
-            return "/root-folder";
-        },
-        has: sinon.stub(),
-        let: sinon.stub(),
-        inspect: sinon.stub(),
-    };
-
-    const fileConfig = {
-        update: sinon.stub(),
-        get: () => {
-            return ["untouched-folder", "/old-folder/**"];
-          },
-        has: sinon.stub(),
-        let: sinon.stub(),
-        inspect: sinon.stub(),
-    };
-
-    configStub.withArgs("assay").returns(assayConfig);
-    configStub.withArgs("files").returns(fileConfig);
-
-    const directoryController = new DirectoryController();
-    const updateStub = sinon.stub();
-
-    directoryController["setCachedRootFolder"]("/old-folder");
-    const event = {affectsConfiguration: () => true} as vscode.ConfigurationChangeEvent;
-    await directoryController.handleRootConfigurationChange(event);
-
-    // assert old one was removed
-    expect(updateStub.calledWith("readonlyInclude",
-    { "untouched-folder": true, '/root-folder/**': true },
-    vscode.ConfigurationTarget.Global));
-
-  });
 });

--- a/test/suite/controller/lintController.test.ts
+++ b/test/suite/controller/lintController.test.ts
@@ -25,7 +25,7 @@ describe("lintController.ts", async () => {
             },
         ]);
 
-         collection = vscode.languages.createDiagnosticCollection("test-linter");
+        collection = vscode.languages.createDiagnosticCollection("test-linter");
 
         credentialControllerStub = sinon.createStubInstance(CredentialController);
         credentialControllerStub.makeAuthHeader.resolves({ Authorization: "test" });
@@ -51,6 +51,49 @@ describe("lintController.ts", async () => {
 
   afterEach(async () => {
     sinon.restore();
+  });
+
+  describe("toggleDirty()", () => {
+    it("should add a file uri to the set of dirty files when the document is dirty", () => {
+        const uri = vscode.Uri.parse('/test/path/file.txt');
+        const event = { 
+          document: {
+            uri,
+            isDirty: true
+          }
+        };
+        lintController.toggleDirty(event as vscode.TextDocumentChangeEvent);
+        expect(lintController["dirtyFiles"].has(uri.fsPath)).to.be.true;
+      });
+  
+      it("should remove a file uri from the set of dirty files when the document is not dirty", () => {
+        const uri = vscode.Uri.parse('/test/path/file.txt');
+        lintController["dirtyFiles"].add(uri.fsPath);
+        const event = { document: 
+            {
+                uri,
+                isDirty: false
+            },
+            reason: 'ContentChange',
+            contentChanges: [{}]
+         };
+  
+        lintController.toggleDirty(event as unknown as vscode.TextDocumentChangeEvent);
+        expect(lintController["dirtyFiles"].has(uri.fsPath)).to.be.false;
+      });
+  });
+
+  describe("removeDirty()", () => {
+    it("should remove a file uri from the set of dirty files if it exists.", () => {
+        const uri = vscode.Uri.parse('/test/path/file.txt');
+        lintController["dirtyFiles"].add(uri.fsPath);
+        const document = {
+            uri
+        };
+        lintController["dirtyFiles"].add(uri.fsPath);
+        lintController.removeDirty(document as vscode.TextDocument);
+        expect(lintController["dirtyFiles"].has(uri.fsPath)).to.be.false;
+    });
   });
 
   describe("lintWorkspace()", () => {

--- a/test/suite/controller/urlController.test.ts
+++ b/test/suite/controller/urlController.test.ts
@@ -6,6 +6,7 @@ import * as vscode from "vscode";
 
 import { AddonController } from "../../../src/controller/addonController";
 import { DirectoryController } from "../../../src/controller/directoryController";
+import { LintController } from "../../../src/controller/lintController";
 import { UrlController } from "../../../src/controller/urlController";
 
 const context = {
@@ -15,7 +16,9 @@ const context = {
 } as any;
 
 let addonControllerStub: sinon.SinonStubbedInstance<AddonController>,
-directoryControllerStub: sinon.SinonStubbedInstance<DirectoryController>;
+directoryControllerStub: sinon.SinonStubbedInstance<DirectoryController>,
+lintControllerStub: sinon.SinonStubbedInstance<LintController>;
+
 
 let urlController: UrlController;
 
@@ -25,7 +28,8 @@ describe("urlController.ts", async () => {
     beforeEach(() => {
         addonControllerStub = sinon.createStubInstance(AddonController);
         directoryControllerStub = sinon.createStubInstance(DirectoryController);
-        urlController = new UrlController(context, addonControllerStub, directoryControllerStub);
+        lintControllerStub = sinon.createStubInstance(LintController);
+        urlController = new UrlController(context, addonControllerStub, directoryControllerStub, lintControllerStub);
     });
 
   afterEach(async () => {

--- a/test/suite/views/lintView.test.ts
+++ b/test/suite/views/lintView.test.ts
@@ -1,0 +1,24 @@
+import { expect } from "chai";
+import { describe, it, afterEach } from "mocha";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+
+import { LintView } from "../../../src/views/lintView";
+
+
+describe("lintView.ts", () => {
+      afterEach(async () => {
+        sinon.restore();
+      });
+
+      describe("getDeleteCommentsPreference", () => {
+        it("should give the user a prompt.", async () => {
+            const showInformationMessageStub = sinon.stub(
+                vscode.window,
+                "showInformationMessage"
+              );
+            LintView.warnOnSave();
+            expect(showInformationMessageStub.called).to.be.true;
+        });
+    });
+});


### PR DESCRIPTION
Closes #88

**Changes**
- Removes the read-only functionality from the linter system.
- Disables the linter on current and subsequent views when the user saves changes/deletes from the version. The linter messages can be activated again by overwriting the local version with a new install.
