### PR TITLE
Run prettier on commentController.test.ts

### DIFF
--- a/test/suite/controller/commentController.test.ts
+++ b/test/suite/controller/commentController.test.ts
@@ -57,25 +57,39 @@ describe("CommentController.ts", () => {
 
   describe("copyLineNumber", () => {
     it("should get the line number.", async () => {
-      sinon.stub(vscode.window, 'activeTextEditor').value({
+      sinon.stub(vscode.window, "activeTextEditor").value({
         document: {
-          uri: '/root/guid/version/filepath.py'
+          uri: "/root/guid/version/filepath.py",
         },
-        selections: [{ start: { line: 0, character: 0 }, end: { line: 0, character: 10 } }],
+        selections: [
+          { start: { line: 0, character: 0 }, end: { line: 0, character: 10 } },
+        ],
       });
-      const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
+      const cmtController = new CommentController(
+        "assay-tester",
+        "Assay Tester",
+        commentCacheControllerStub,
+        directoryControllerStub
+      );
       const result = await cmtController.copyLineNumber();
       expect(result).to.equal("* filepath#L1\n");
     });
 
     it("should get the line numbers.", async () => {
-      sinon.stub(vscode.window, 'activeTextEditor').value({
+      sinon.stub(vscode.window, "activeTextEditor").value({
         document: {
-          uri: '/root/guid/version/filepath.py'
+          uri: "/root/guid/version/filepath.py",
         },
-        selections: [{ start: { line: 0, character: 0 }, end: { line: 4, character: 10 } }],
+        selections: [
+          { start: { line: 0, character: 0 }, end: { line: 4, character: 10 } },
+        ],
       });
-      const cmtController = new CommentController("assay-tester", "Assay Tester", commentCacheControllerStub, directoryControllerStub);
+      const cmtController = new CommentController(
+        "assay-tester",
+        "Assay Tester",
+        commentCacheControllerStub,
+        directoryControllerStub
+      );
       const result = await cmtController.copyLineNumber();
       expect(result).to.equal("* filepath#L1-5\n");
     });


### PR DESCRIPTION
Looks like #104 needed to be rebased because it had a small stylistic issue. This PR fixes it now.