### PR TITLE
Change CircleCI Status Badge to PNG rather than SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Welcome to **Assay**!
 
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/mozilla/assay/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/mozilla/assay/tree/main)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/mozilla/assay/tree/main.png)](https://dl.circleci.com/status-badge/redirect/gh/mozilla/assay/tree/main)
 
 > Assay: The testing of a metal (Addon) or ore (Addon) to determine its ingredients (functionalities) and quality (quality).
 


### PR DESCRIPTION
`vsce` doesn't like SVGs in the README even though it's fine with the extension itself using them. See [here](https://github.com/gitpod-io/gitpod/issues/8030)

Fails`npm run build` -- 

`ERROR  SVGs are restricted in README.md; please use other file image formats, such as PNG: https://dl.circleci.com/status-badge/img/gh/mozilla/assay/tree/main.svg?style=svg`