### PR TITLE
Fix: Prevent Context Menu Commands From Conflicting with Other Extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
         {
           "command": "assay.copyLineNumber",
           "when": "editorTextFocus",
-          "group": "navigation@1"
+          "group": "navigation@0"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -203,12 +203,12 @@
         {
           "command": "assay.addComment",
           "when": "editorTextFocus",
-          "group": "navigation@1"
+          "group": "navigation@0"
         },
         {
           "command": "assay.copyLineNumber",
           "when": "editorTextFocus",
-          "group": "navigation@2"
+          "group": "navigation@1"
         }
       ]
     },


### PR DESCRIPTION
Closes #116

Avoids conflict with other extensions also putting their context commands at `navigation@1`, or at least as much as possible, without moving Assay's commands to the bottom of the context menu in its own section.

![image](https://github.com/user-attachments/assets/5bc77c66-ac78-4d41-a68d-56adc33430a7)
