### PR TITLE
Correctly Terminate Activate() When Not in Root

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,12 +202,12 @@
       "editor/context": [
         {
           "command": "assay.addComment",
-          "when": "editorTextFocus",
+          "when": "editorTextFocus && assay.commentsEnabled",
           "group": "navigation@0"
         },
         {
           "command": "assay.copyLineNumber",
-          "when": "editorTextFocus",
+          "when": "editorTextFocus && assay.commentsEnabled",
           "group": "navigation@0"
         }
       ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -156,7 +156,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const workspace = vscode.workspace.workspaceFolders;
   if (workspace) {
     const uri = workspace[0].uri;
-    if (!directoryController.inRoot(uri)) {
+    if (!await directoryController.inRoot(uri)) {
       return;
     }
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -156,7 +156,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const workspace = vscode.workspace.workspaceFolders;
   if (workspace) {
     const uri = workspace[0].uri;
-    if (!await directoryController.inRoot(uri)) {
+    if (!(await directoryController.inRoot(uri))) {
       return;
     }
   }

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -47,6 +47,10 @@ describe("extension.ts", () => {
       "getRootFolderPath"
     );
     directoryControllerStub.resolves("test");
+
+    const inRootStub = sinon.stub(DirectoryController.prototype, "inRoot");
+    inRootStub.resolves(true);
+
     const existsSyncStub = sinon.stub(fs, "existsSync");
     existsSyncStub.returns(true);
 


### PR DESCRIPTION
Fixes #115, fixes #118

`/Projects/assay/src/extension.ts#L159` was always returning true due to no await.
