### PR TITLE
More Strictly Determine the Root Folder

### DIFF
--- a/src/controller/commentCacheController.ts
+++ b/src/controller/commentCacheController.ts
@@ -180,7 +180,7 @@ export class CommentCacheController {
   /**
    * Error-checking for uris that are passed into the controller.
    */
-  private async checkUri(uri: vscode.Uri, strict?: boolean) {
+  async checkUri(uri: vscode.Uri, strict?: boolean) {
     const { guid, version } = await this.directoryController.splitUri(uri);
     if (!(await this.directoryController.inRoot(uri))) {
       vscode.window.showErrorMessage(

--- a/src/controller/commentCacheController.ts
+++ b/src/controller/commentCacheController.ts
@@ -72,7 +72,7 @@ export class CommentCacheController {
   // To avoid iterating by each individual comment, we can knit together
   // the uri when iterating by file.
   async deleteComments(uri: vscode.Uri) {
-    this.checkUri(uri);
+    this.directoryController.checkUri(uri);
     const { guid, version } = await this.directoryController.splitUri(uri);
     const rootPath = await this.directoryController.getRootFolderPath();
     const comments = await this.cache.getFromCache([guid, version]);
@@ -128,7 +128,7 @@ export class CommentCacheController {
    * @returns whether comments were deleted from uri.
    */
   async exportVersionComments(uri: vscode.Uri) {
-    this.checkUri(uri, true);
+    this.directoryController.checkUri(uri, true);
     const { guid, version } = await this.directoryController.splitUri(uri);
     const comments = await this.compileComments(guid, version);
     return await this.exportCommentsToDocument(comments, uri);
@@ -175,26 +175,6 @@ export class CommentCacheController {
       await this.deleteComments(uri);
     }
     return deleteCachedComments;
-  }
-
-  /**
-   * Error-checking for uris that are passed into the controller.
-   */
-  async checkUri(uri: vscode.Uri, strict?: boolean) {
-    const { guid, version } = await this.directoryController.splitUri(uri);
-    if (!(await this.directoryController.inRoot(uri))) {
-      vscode.window.showErrorMessage(
-        "(Assay) File is not in the Addons root folder."
-      );
-      throw new Error("File is not in the root folder");
-    }
-
-    if (strict && (!guid || !version)) {
-      vscode.window.showErrorMessage(
-        "Not a valid path. Ensure you are at least as deep as the version folder."
-      );
-      throw new Error("No guid or version found");
-    }
   }
 
   /**

--- a/src/controller/commentCacheController.ts
+++ b/src/controller/commentCacheController.ts
@@ -181,9 +181,8 @@ export class CommentCacheController {
    * Error-checking for uris that are passed into the controller.
    */
   private async checkUri(uri: vscode.Uri, strict?: boolean) {
-    const { rootFolder, fullPath, guid, version } =
-      await this.directoryController.splitUri(uri);
-    if (!fullPath.startsWith(rootFolder)) {
+    const { guid, version } = await this.directoryController.splitUri(uri);
+    if (!(await this.directoryController.inRoot(uri))) {
       vscode.window.showErrorMessage(
         "(Assay) File is not in the Addons root folder."
       );

--- a/src/controller/commentController.ts
+++ b/src/controller/commentController.ts
@@ -189,9 +189,10 @@ export class CommentController {
    * @returns The guid, version, and filepath of the thread.
    */
   private async getFilepathInfo(thread: AssayThread) {
-    const { rootFolder, fullPath, guid, version, filepath } =
-      await this.directoryController.splitUri(thread.uri);
-    if (!fullPath.startsWith(rootFolder)) {
+    const { guid, version, filepath } = await this.directoryController.splitUri(
+      thread.uri
+    );
+    if (!(await this.directoryController.inRoot(thread.uri))) {
       vscode.window.showErrorMessage(
         "(Assay) File is not in the Addons root folder."
       );

--- a/src/controller/commentController.ts
+++ b/src/controller/commentController.ts
@@ -192,12 +192,7 @@ export class CommentController {
     const { guid, version, filepath } = await this.directoryController.splitUri(
       thread.uri
     );
-    if (!(await this.directoryController.inRoot(thread.uri))) {
-      vscode.window.showErrorMessage(
-        "(Assay) File is not in the Addons root folder."
-      );
-      throw new Error("File is not in the root folder.");
-    }
+    await this.commentCacheController.checkUri(thread.uri);
     return { guid, version, filepath };
   }
 

--- a/src/controller/commentController.ts
+++ b/src/controller/commentController.ts
@@ -192,7 +192,7 @@ export class CommentController {
     const { guid, version, filepath } = await this.directoryController.splitUri(
       thread.uri
     );
-    await this.commentCacheController.checkUri(thread.uri);
+    await this.directoryController.checkUri(thread.uri);
     return { guid, version, filepath };
   }
 

--- a/src/controller/directoryController.ts
+++ b/src/controller/directoryController.ts
@@ -27,12 +27,12 @@ export class DirectoryController {
       vscode.window.showErrorMessage(
         "(Assay) File is not in the Addons root folder."
       );
-      throw new Error("File is not in the root folder");
+      throw new Error("(Assay) File is not in the root folder");
     }
 
     if (strict && (!guid || !version)) {
       vscode.window.showErrorMessage(
-        "Not a valid path. Ensure you are at least as deep as the version folder."
+        "Not a valid path. Ensure you have the workspace open to the add-ons root folder."
       );
       throw new Error("No guid or version found");
     }
@@ -91,10 +91,7 @@ export class DirectoryController {
   async inRoot(uri: vscode.Uri) {
     const { rootFolder, fullPath } = await this.splitUri(uri);
     const rel = path.relative(rootFolder, fullPath);
-    if (!rel.startsWith("..")) {
-      return true;
-    }
-    return false;
+    return !rel.startsWith("..");
   }
 
   /**

--- a/src/controller/directoryController.ts
+++ b/src/controller/directoryController.ts
@@ -70,7 +70,8 @@ export class DirectoryController {
    */
   async inRoot(uri: vscode.Uri) {
     const { rootFolder, fullPath } = await this.splitUri(uri);
-    if (fullPath.startsWith(rootFolder)) {
+    const rel = path.relative(rootFolder, fullPath);
+    if (!rel.startsWith("..")) {
       return true;
     }
     return false;

--- a/src/controller/directoryController.ts
+++ b/src/controller/directoryController.ts
@@ -19,6 +19,26 @@ export class DirectoryController {
   }
 
   /**
+   * Error-checking for uris that are passed into the controller.
+   */
+  async checkUri(uri: vscode.Uri, strict?: boolean) {
+    const { guid, version } = await this.splitUri(uri);
+    if (!(await this.inRoot(uri))) {
+      vscode.window.showErrorMessage(
+        "(Assay) File is not in the Addons root folder."
+      );
+      throw new Error("File is not in the root folder");
+    }
+
+    if (strict && (!guid || !version)) {
+      vscode.window.showErrorMessage(
+        "Not a valid path. Ensure you are at least as deep as the version folder."
+      );
+      throw new Error("No guid or version found");
+    }
+  }
+
+  /**
    * Gets the root folder stored in config.
    * @returns the root folder in config.
    */

--- a/src/controller/directoryController.ts
+++ b/src/controller/directoryController.ts
@@ -19,7 +19,7 @@ export class DirectoryController {
   }
 
   /**
-   * Error-checking for uris that are passed into the controller.
+   * Check whether a given uri is in the root folder and prompt the user accordingly.
    */
   async checkUri(uri: vscode.Uri, strict?: boolean) {
     const { guid, version } = await this.splitUri(uri);

--- a/src/controller/statusBarController.ts
+++ b/src/controller/statusBarController.ts
@@ -17,7 +17,7 @@ export class StatusBarController {
 
   /**
    * Updates the status bar.
-   * @returns whether the status bar was updated.
+   * @returns whether the status bar is updated and shown.
    */
   async updateStatusBar() {
     const activeEditor = vscode.window.activeTextEditor;
@@ -26,20 +26,16 @@ export class StatusBarController {
     }
 
     const doc = activeEditor.document;
-    const filePath = doc.uri.fsPath;
-    const rootFolder = await this.directoryController.getRootFolderPath();
-
     if (!(await this.directoryController.inRoot(doc.uri))) {
       this.reviewItem.hide();
-      throw new Error("File is not in the root folder.");
+      return false;
     }
 
-    const relativePath = filePath.replace(rootFolder, "");
-    const guid = relativePath.split(path.sep)[1];
+    const { guid } = await this.directoryController.splitUri(doc.uri);
 
     if (!guid) {
       this.reviewItem.hide();
-      throw new Error("No guid found.");
+      return false;
     }
 
     const reviewUrl = await this.addonCacheController.getAddonFromCache([

--- a/src/controller/statusBarController.ts
+++ b/src/controller/statusBarController.ts
@@ -28,7 +28,8 @@ export class StatusBarController {
     const doc = activeEditor.document;
     const filePath = doc.uri.fsPath;
     const rootFolder = await this.directoryController.getRootFolderPath();
-    if (!filePath.startsWith(rootFolder)) {
+
+    if (!(await this.directoryController.inRoot(doc.uri))) {
       this.reviewItem.hide();
       throw new Error("File is not in the root folder.");
     }

--- a/test/suite/controller/commentCacheController.test.ts
+++ b/test/suite/controller/commentCacheController.test.ts
@@ -51,33 +51,6 @@ describe("commentCacheController.ts", () => {
     });
   });
 
-  describe("checkUri()", () => {
-    it("should throw an error if the file is not in the root folder.", async () => {
-      directoryControllerStub.splitUri.resolves({
-        rootFolder: "/test-root",
-        fullPath: "/not-root",
-      } as any);
-      try {
-        await commentCacheController["checkUri"](vscode.Uri.file("/not-root"));
-      } catch (err: any) {
-        expect(err.message).to.equal("File is not in the root folder");
-      }
-    });
-
-    it("should throw an error if there is no guid or version.", async () => {
-      directoryControllerStub.inRoot.resolves(true);
-      directoryControllerStub.splitUri.resolves({
-        rootFolder: "/test-root",
-        fullPath: "/test-root",
-      } as any);
-      try {
-        await commentCacheController["checkUri"](vscode.Uri.file("/test-root"));
-      } catch (err: any) {
-        expect(err.message).to.equal("No guid or version found");
-      }
-    });
-  });
-
   describe("deleteComments", () => {
     it("should delete all comments in the URI's GUID and version.", async () => {
       directoryControllerStub.splitUri.resolves({

--- a/test/suite/controller/commentCacheController.test.ts
+++ b/test/suite/controller/commentCacheController.test.ts
@@ -65,6 +65,7 @@ describe("commentCacheController.ts", () => {
     });
 
     it("should throw an error if there is no guid or version.", async () => {
+      directoryControllerStub.inRoot.resolves(true);
       directoryControllerStub.splitUri.resolves({
         rootFolder: "/test-root",
         fullPath: "/test-root",

--- a/test/suite/controller/commentController.test.ts
+++ b/test/suite/controller/commentController.test.ts
@@ -97,6 +97,7 @@ describe("CommentController.ts", () => {
 
   describe("addComment", () => {
     it("should create a comment.", async () => {
+      directoryControllerStub.inRoot.resolves(true);
       sinon.stub(vscode.window, "activeTextEditor").value({
         document: {
           uri: "test-uri",
@@ -120,6 +121,7 @@ describe("CommentController.ts", () => {
 
   describe("deleteThread", () => {
     it("should delete the comment thread from a controller and its comments from cache.", async () => {
+      directoryControllerStub.inRoot.resolves(true);
       const cmtController = new CommentController(
         "assay-tester",
         "Assay Tester",
@@ -267,6 +269,7 @@ describe("CommentController.ts", () => {
 
   describe("getThreadLocation()", () => {
     it("should return the thread's Uri guid, version, filepath and range.", async () => {
+      directoryControllerStub.inRoot.resolves(true);
       const cmtController = new CommentController(
         "assay-tester",
         "Assay Tester",

--- a/test/suite/controller/directoryController.test.ts
+++ b/test/suite/controller/directoryController.test.ts
@@ -6,6 +6,8 @@ import * as vscode from "vscode";
 
 import { DirectoryController } from "../../../src/controller/directoryController";
 
+const directoryController = new DirectoryController();
+
 describe("directoryController.ts", async () => {
   afterEach(() => {
     sinon.restore();
@@ -15,13 +17,39 @@ describe("directoryController.ts", async () => {
     it("should fetch the desired line from the given line number and uri", async () => {
       const uri = vscode.Uri.file("/test/path");
       const buffer = Buffer.from("Line 0\nLine 1\nLine 2");
-      const directoryController = new DirectoryController();
       const readFileStub = sinon
         .stub(directoryController, "readFile")
         .resolves(buffer);
       const result = await directoryController.getLineFromFile(uri, 2);
       expect(readFileStub.called).to.be.true;
       expect(result).to.equal("Line 2");
+    });
+  });
+
+  describe("checkUri()", () => {
+    it("should throw an error if the file is not in the root folder.", async () => {
+      sinon.stub(directoryController, "splitUri").resolves({
+        rootFolder: "/test-root",
+        fullPath: "/test-root",
+      } as any);
+      try {
+        await directoryController.checkUri(vscode.Uri.file("/not-root"));
+      } catch (err: any) {
+        expect(err.message).to.equal("File is not in the root folder");
+      }
+    });
+
+    it("should throw an error if there is no guid or version.", async () => {
+      sinon.stub(directoryController, "inRoot").resolves(true);
+      sinon.stub(directoryController, "splitUri").resolves({
+        rootFolder: "/test-root",
+        fullPath: "/test-root",
+      } as any);
+      try {
+        await directoryController.checkUri(vscode.Uri.file("/test-root"));
+      } catch (err: any) {
+        expect(err.message).to.equal("No guid or version found");
+      }
     });
   });
 

--- a/test/suite/controller/directoryController.test.ts
+++ b/test/suite/controller/directoryController.test.ts
@@ -77,8 +77,6 @@ describe("directoryController.ts", async () => {
       configStub.withArgs("assay").returns(assayConfig);
       configStub.withArgs("files").returns(fileConfig);
 
-      const directoryController = new DirectoryController();
-
       const existsSyncStub = sinon.stub(fs, "existsSync");
       existsSyncStub.returns(true);
 
@@ -110,8 +108,6 @@ describe("directoryController.ts", async () => {
 
       configStub.withArgs("assay").returns(assayConfig);
       configStub.withArgs("files").returns(fileConfig);
-
-      const directoryController = new DirectoryController();
 
       const showOpenDialogStub = sinon.stub(vscode.window, "showOpenDialog");
       showOpenDialogStub.resolves(undefined);
@@ -152,8 +148,6 @@ describe("directoryController.ts", async () => {
 
       configStub.withArgs("assay").returns(assayConfig);
       configStub.withArgs("files").returns(fileConfig);
-
-      const directoryController = new DirectoryController();
 
       const showOpenDialogStub = sinon.stub(vscode.window, "showOpenDialog");
       const uri = vscode.Uri.file("test");

--- a/test/suite/controller/statusBarController.test.ts
+++ b/test/suite/controller/statusBarController.test.ts
@@ -79,8 +79,8 @@ describe("statusBarController.ts", async () => {
     });
 
     it("should throw an error if there is no guid in the path.", async () => {
+      directoryControllerStub.inRoot.resolves(true);
       directoryControllerStub.getRootFolderPath.resolves("/test");
-
       const activeTextEditorStub = sinon.stub();
       activeTextEditorStub.returns(fakeActiveEditor);
       sinon.replaceGetter(
@@ -101,6 +101,7 @@ describe("statusBarController.ts", async () => {
     });
 
     it("should return true if the taskbar is updated.", async () => {
+      directoryControllerStub.inRoot.resolves(true);
       directoryControllerStub.getRootFolderPath.resolves("/root");
 
       const activeTextEditorStub = sinon.stub();

--- a/test/suite/controller/statusBarController.test.ts
+++ b/test/suite/controller/statusBarController.test.ts
@@ -56,7 +56,7 @@ describe("statusBarController.ts", async () => {
       expect(await statusBarController.updateStatusBar()).to.be.false;
     });
 
-    it("should throw error if the folder is not in the root.", async () => {
+    it("should return false if the folder is not in the root.", async () => {
       directoryControllerStub.getRootFolderPath.resolves("/different-root");
 
       const activeTextEditorStub = sinon.stub();
@@ -70,17 +70,16 @@ describe("statusBarController.ts", async () => {
       const existsSyncStub = sinon.stub(fs, "existsSync");
       existsSyncStub.returns(true);
 
-      try {
-        await statusBarController.updateStatusBar();
-        expect.fail("No error thrown");
-      } catch (err: any) {
-        expect(err.message).to.equal("File is not in the root folder.");
-      }
+      const result = await statusBarController.updateStatusBar();
+      expect(result).to.be.false;
     });
 
-    it("should throw an error if there is no guid in the path.", async () => {
+    it("should return false if there is no guid in the path.", async () => {
       directoryControllerStub.inRoot.resolves(true);
-      directoryControllerStub.getRootFolderPath.resolves("/test");
+      directoryControllerStub.splitUri.resolves({
+        guid: undefined,
+      } as any);
+
       const activeTextEditorStub = sinon.stub();
       activeTextEditorStub.returns(fakeActiveEditor);
       sinon.replaceGetter(
@@ -92,17 +91,15 @@ describe("statusBarController.ts", async () => {
       const existsSyncStub = sinon.stub(fs, "existsSync");
       existsSyncStub.returns(true);
 
-      try {
-        await statusBarController.updateStatusBar();
-        expect.fail("No error thrown");
-      } catch (err: any) {
-        expect(err.message).to.equal("No guid found.");
-      }
+      const result = await statusBarController.updateStatusBar();
+      expect(result).to.be.false;
     });
 
     it("should return true if the taskbar is updated.", async () => {
       directoryControllerStub.inRoot.resolves(true);
-      directoryControllerStub.getRootFolderPath.resolves("/root");
+      directoryControllerStub.splitUri.resolves({
+        guid: "guid",
+      } as any);
 
       const activeTextEditorStub = sinon.stub();
       activeTextEditorStub.returns(fakeActiveEditorWithGuid);


### PR DESCRIPTION
Fixes #120

**Changes**
- Changed how root folder is determined to be more strict
- Removed duplicate code relating to root folder checks, routing them all through helper functions\
- Changed `updateStatusBar()` from throwing errors to returning false (since it could do the prior constantly outside of addons folder and in regular VS Code use).