### PR TITLE
Handle Case Where Fetched Lint does not have File Attribute

### DIFF
--- a/src/controller/lintController.ts
+++ b/src/controller/lintController.ts
@@ -225,11 +225,12 @@ export class LintController {
 
   /**
    * Returns a lint's filepath's location on disk.
+   * If filepath is undefined, returns the versionPath.
    * @param versionPath The path to the version folder.
    * @param filepath The filepath within the version.
    * @returns the URI location.
    */
   private getUriFromVersionPath(versionPath: string, filepath: string) {
-    return vscode.Uri.file(path.join(versionPath, filepath));
+    return vscode.Uri.file(path.join(versionPath, filepath ?? ""));
   }
 }

--- a/test/suite/controller/lintController.test.ts
+++ b/test/suite/controller/lintController.test.ts
@@ -113,6 +113,13 @@ describe("lintController.ts", async () => {
         messages: [
           {
             type: "error",
+            code: "no file",
+            message: "i have no file!",
+            description: "description",
+            line: 1,
+          },
+          {
+            type: "error",
             code: "error code",
             message: "error message",
             description: "description",
@@ -152,6 +159,9 @@ describe("lintController.ts", async () => {
       } as unknown as Response);
 
       await lintController.lintWorkspace();
+
+      const versionUri = vscode.Uri.parse("version");
+      expect(collection.get(versionUri)?.length).to.be.equal(1);
 
       const errorUri = vscode.Uri.parse("version/file1.js");
       expect(collection.has(errorUri)).to.be.equal(true);

--- a/test/suite/controller/lintController.test.ts
+++ b/test/suite/controller/lintController.test.ts
@@ -114,7 +114,7 @@ describe("lintController.ts", async () => {
           {
             type: "error",
             code: "no file",
-            message: "i have no file!",
+            message: "i am a general message",
             description: "description",
             line: 1,
           },


### PR DESCRIPTION
Fixes #128.

Handles the case where a certain lint does not have the 'file' attribute. Places the lint directly on the version folder.

![image](https://github.com/user-attachments/assets/d95b109e-cc91-4d9c-8e59-7f1a85302be9)
