### PR TITLE
Fix Updating Functionality

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -145,7 +145,7 @@ export async function activate(context: vscode.ExtensionContext) {
     assayUpdaterDisposable
   );
 
-  UpdateHelper.updateAssay();
+  UpdateHelper.updateAssay(false);
 
   await vscode.commands.executeCommand(
     "setContext",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -145,6 +145,8 @@ export async function activate(context: vscode.ExtensionContext) {
     assayUpdaterDisposable
   );
 
+  UpdateHelper.updateAssay();
+
   await vscode.commands.executeCommand(
     "setContext",
     "assay.commentsEnabled",

--- a/src/helper/updateHelper.ts
+++ b/src/helper/updateHelper.ts
@@ -6,17 +6,24 @@ import * as vscode from "vscode";
 
 export class UpdateHelper {
   /**
-   * Updates Assay.
-   * @returns Whether Assay was updated.
+   * Checks whether a new version of Assay is available.
+   * Prompts the user for the option to update.
    */
   static async updateAssay() {
     const downloadInfo = await UpdateHelper.checkAndGetNewVersion();
-    if (!downloadInfo) {
-      return false;
+    if (downloadInfo) {
+      const { downloadLink, currentVersion, version } = downloadInfo;
+      vscode.window
+        .showInformationMessage(
+          `A new version of Assay is available (${version}) from your current version (${currentVersion}). Would you like to update?`,
+          "Update Assay"
+        )
+        .then((value) => {
+          if(value){
+            UpdateHelper.installNewVersion(downloadLink, version);
+          }
+        });
     }
-    const { downloadLink, version } = downloadInfo.downloadLink;
-    UpdateHelper.installNewVersion(downloadLink, version);
-    return true;
   }
 
   /**
@@ -25,6 +32,13 @@ export class UpdateHelper {
    * @param version The version installed.
    */
   private static async installNewVersion(downloadUrl: string, version: string) {
+    const versionProcess = spawn("code", ["--version"]);
+    versionProcess.on("error", () => {
+      vscode.window.showErrorMessage(
+        "'code' command not found in PATH. Please add it via the VS Code Command Palette and try again."
+      );
+    });
+
     const savePath = await UpdateHelper.downloadVersion(downloadUrl);
     const downloadProcess = spawn("code", ["--install-extension", savePath]);
 
@@ -73,15 +87,16 @@ export class UpdateHelper {
         }
         const savePath = path.join(extensionPath, "version.vsix");
 
-        try {
-          const dest = fs.createWriteStream(savePath, { flags: "w" });
-          dest.write(await response.buffer());
-          dest.close();
-        } catch (err: any) {
-          throw new Error(`Could not write version file: ${err.message}`);
-        }
-
-        return savePath;
+        const buffer = await response.buffer();
+        return new Promise<string>((resolve, reject) => {
+          fs.writeFile(savePath, buffer, { flag: "w" }, (err) => {
+            if (err) {
+              reject(new Error(`Could not write version file: ${err.message}`));
+            } else {
+              resolve(savePath);
+            }
+          });
+        });
       }
     );
   }
@@ -103,17 +118,18 @@ export class UpdateHelper {
     const json = await response.json();
     const latestVersion = json.tag_name;
     const currentVersion =
-      vscode.extensions.getExtension("mozilla.assay")?.packageJSON.version;
+      'v' + vscode.extensions.getExtension("mozilla.assay")?.packageJSON.version;
 
     if (latestVersion !== currentVersion) {
       return {
         downloadLink: json.assets[0].browser_download_url,
         version: latestVersion,
+        currentVersion,
       };
     }
 
     vscode.window.showInformationMessage(
-      `Assay is up to date (version ${currentVersion})`
+      `Assay is up to date (${currentVersion}).`
     );
   }
 }

--- a/src/helper/updateHelper.ts
+++ b/src/helper/updateHelper.ts
@@ -124,15 +124,13 @@ export class UpdateHelper {
       "v" +
       vscode.extensions.getExtension("mozilla.assay")?.packageJSON.version;
 
-    if (latestVersion !== currentVersion) {
-      return {
-        downloadLink: json.assets[0].browser_download_url,
-        version: latestVersion,
-        currentVersion,
-      };
-    }
+    const downloadLink =
+      latestVersion !== currentVersion
+        ? json.assets[0].browser_download_url
+        : undefined;
 
     return {
+      downloadLink,
       version: latestVersion,
       currentVersion,
     };

--- a/src/helper/updateHelper.ts
+++ b/src/helper/updateHelper.ts
@@ -8,21 +8,24 @@ export class UpdateHelper {
   /**
    * Checks whether a new version of Assay is available.
    * Prompts the user for the option to update.
+   * @param confirmLatest Whether to prompt that the version is up to date.
    */
-  static async updateAssay() {
-    const downloadInfo = await UpdateHelper.checkAndGetNewVersion();
-    if (downloadInfo) {
-      const { downloadLink, currentVersion, version } = downloadInfo;
+  static async updateAssay(confirmLatest = true) {
+    const { downloadLink, currentVersion, version } =
+      await UpdateHelper.checkAndGetNewVersion();
+    if (downloadLink) {
       vscode.window
         .showInformationMessage(
           `A new version of Assay is available (${version}) from your current version (${currentVersion}). Would you like to update?`,
           "Update Assay"
         )
         .then((value) => {
-          if(value){
+          if (value) {
             UpdateHelper.installNewVersion(downloadLink, version);
           }
         });
+    } else if (confirmLatest) {
+      vscode.window.showInformationMessage(`Assay is up to date (${version}).`);
     }
   }
 
@@ -118,7 +121,8 @@ export class UpdateHelper {
     const json = await response.json();
     const latestVersion = json.tag_name;
     const currentVersion =
-      'v' + vscode.extensions.getExtension("mozilla.assay")?.packageJSON.version;
+      "v" +
+      vscode.extensions.getExtension("mozilla.assay")?.packageJSON.version;
 
     if (latestVersion !== currentVersion) {
       return {
@@ -128,8 +132,9 @@ export class UpdateHelper {
       };
     }
 
-    vscode.window.showInformationMessage(
-      `Assay is up to date (${currentVersion}).`
-    );
+    return {
+      version: latestVersion,
+      currentVersion,
+    };
   }
 }

--- a/src/helper/updateHelper.ts
+++ b/src/helper/updateHelper.ts
@@ -9,10 +9,11 @@ export class UpdateHelper {
    * Checks whether a new version of Assay is available.
    * Prompts the user for the option to update.
    * @param confirmLatest Whether to prompt that the version is up to date.
+   * @returns whether Assay is outdated.
    */
   static async updateAssay(confirmLatest = true) {
     const { downloadLink, currentVersion, version } =
-      await UpdateHelper.checkAndGetNewVersion();
+      (await UpdateHelper.checkAndGetNewVersion()) || {};
     if (downloadLink) {
       vscode.window
         .showInformationMessage(
@@ -24,8 +25,10 @@ export class UpdateHelper {
             UpdateHelper.installNewVersion(downloadLink, version);
           }
         });
+      return true;
     } else if (confirmLatest) {
       vscode.window.showInformationMessage(`Assay is up to date (${version}).`);
+      return false;
     }
   }
 


### PR DESCRIPTION
Fixes #127. Also adds:
1. Checking for updates on extension launch
2. Prevention of race condition when downloading new version
3. More informative messaging on versioning
4. Error when `code` is not in PATH (As updating does not work otherwise).

![image](https://github.com/user-attachments/assets/a280804d-5114-44ec-a49a-ac6984dd8ed8)
