### PR TITLE
Do Not Fully Initialize Assay if Not In Workspace

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,8 +154,8 @@ export async function activate(context: vscode.ExtensionContext) {
   // Do not launch commenting system if not in the rootFolder.
   // Still allows Assay to be launched to use other commands (setup, installs).
   const workspace = vscode.workspace.workspaceFolders;
-  
-  if(!workspace || !(await directoryController.inRoot(workspace[0].uri))){
+
+  if (!workspace || !(await directoryController.inRoot(workspace[0].uri))) {
     return;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,11 +154,9 @@ export async function activate(context: vscode.ExtensionContext) {
   // Do not launch commenting system if not in the rootFolder.
   // Still allows Assay to be launched to use other commands (setup, installs).
   const workspace = vscode.workspace.workspaceFolders;
-  if (workspace) {
-    const uri = workspace[0].uri;
-    if (!(await directoryController.inRoot(uri))) {
-      return;
-    }
+  
+  if(!workspace || !(await directoryController.inRoot(workspace[0].uri))){
+    return;
   }
 
   await vscode.commands.executeCommand(

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -73,28 +73,11 @@ describe("extension.ts", () => {
   });
 
   it("should return early if no workspace is available", async () => {
-    return;
-  });
-
-  it("should return early if the workspace is not in root", async () => {
-    const workspaceFoldersStub = sinon.stub(
-      vscode.workspace,
-      "workspaceFolders"
-    );
-    workspaceFoldersStub.value([
-      {
-        uri: vscode.Uri.parse("test-root-uri"),
-      },
-    ]);
-
     const directoryControllerStub = sinon.stub(
       DirectoryController.prototype,
       "getRootFolderPath"
     );
     directoryControllerStub.resolves("test");
-
-    const inRootStub = sinon.stub(DirectoryController.prototype, "inRoot");
-    inRootStub.resolves(false);
 
     const context = makeContext();
     sinon.stub(context.globalState, "get").withArgs("filePath").returns("test");


### PR DESCRIPTION
Closes #124

**Changes**
- Avoids the complications with single files altogether by not allowing Assay to be used without a workspace.