### PR TITLE
Rename Assay Sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
       "explorer": [
         {
           "id": "assayCommands",
-          "name": "Addons",
+          "name": "Assay",
           "icon": "media/assay.svg"
         }
       ]


### PR DESCRIPTION
Relates to  #129

**Changes**
- Renames the Assay sidebar from 'Addons' to 'Assay' to stand out more.
![image](https://github.com/user-attachments/assets/b9d23d73-1696-4205-becc-ee33d927ab06)
