### PR TITLE
Add Share Button to Context Menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,10 @@
         {
           "command": "assay.copyLink",
           "when": "false"
+        },
+        {
+          "command": "assay.copyLinkFromContext",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -207,6 +211,11 @@
         },
         {
           "command": "assay.copyLineNumber",
+          "when": "editorTextFocus && assay.commentsEnabled",
+          "group": "navigation@0"
+        },
+        {
+          "command": "assay.copyLinkFromContext",
           "when": "editorTextFocus && assay.commentsEnabled",
           "group": "navigation@0"
         }
@@ -299,7 +308,12 @@
       },
       {
         "command": "assay.copyLink",
-        "title": "Copy Link",
+        "title": "Share Link",
+        "icon": "$(assay-share)"
+      },
+      {
+        "command": "assay.copyLinkFromContext",
+        "title": "(Assay) Share Link",
         "icon": "$(assay-share)"
       }
     ]

--- a/src/controller/commentController.ts
+++ b/src/controller/commentController.ts
@@ -147,18 +147,6 @@ export class CommentController {
     return this.createLink(guid, version, filepath, range);
   }
 
-  private createLink(
-    guid: string,
-    version: string,
-    filepath: string,
-    range: string
-  ) {
-    const link = `vscode://mozilla.assay/review/${guid}/${version}?path=${filepath}${range}`;
-    vscode.env.clipboard.writeText(link);
-    vscode.window.showInformationMessage("Link copied to clipboard.");
-    return link;
-  }
-
   /**
    * Fetches the location of a thread.
    * @param thread The thread to locate.
@@ -175,6 +163,22 @@ export class CommentController {
    */
   dispose() {
     this.controller.dispose();
+  }
+
+  /**
+   * Compiles and sets the clipboard to an Assay link to a specific line.
+   * @returns the generated link.
+   */
+  private createLink(
+    guid: string,
+    version: string,
+    filepath: string,
+    range: string
+  ) {
+    const link = `vscode://mozilla.assay/review/${guid}/${version}?path=${filepath}${range}`;
+    vscode.env.clipboard.writeText(link);
+    vscode.window.showInformationMessage("Link copied to clipboard.");
+    return link;
   }
 
   /**

--- a/src/controller/commentController.ts
+++ b/src/controller/commentController.ts
@@ -111,6 +111,27 @@ export class CommentController {
   }
 
   /**
+   * Copies a link to the selected line(s) to the clipboard for sharing from a context menu.
+   * @param thread The thread containing the selected lines
+   * @return the generated link.
+   */
+  async copyLinkFromContext() {
+    const editor = vscode.window.activeTextEditor;
+    if (editor) {
+      const document = editor.document;
+      const { guid, version, filepath } = await this.directoryController.splitUri(
+        document.uri
+      );
+      const selection = editor.selections[0];
+      const endCharacter = document.lineAt(selection.end).text.length;
+      const range = RangeHelper.fromSelection(selection, endCharacter);
+      return this.createLink(guid, version, filepath,  RangeHelper.toString(range));
+    } else {
+      throw new Error("No active text editor found.");
+    }
+  }
+
+  /**
    * Copies a link to the selected line(s) to the clipboard for sharing.
    * @param thread The thread containing the selected lines
    * @return the generated link.
@@ -119,6 +140,10 @@ export class CommentController {
     const { guid, version, filepath, range } = await this.getThreadLocation(
       thread
     );
+    return this.createLink(guid, version, filepath, range);
+  }
+
+  private createLink(guid: string, version: string, filepath: string, range: string){
     const link = `vscode://mozilla.assay/review/${guid}/${version}?path=${filepath}${range}`;
     vscode.env.clipboard.writeText(link);
     vscode.window.showInformationMessage("Link copied to clipboard.");

--- a/src/controller/commentController.ts
+++ b/src/controller/commentController.ts
@@ -119,13 +119,17 @@ export class CommentController {
     const editor = vscode.window.activeTextEditor;
     if (editor) {
       const document = editor.document;
-      const { guid, version, filepath } = await this.directoryController.splitUri(
-        document.uri
-      );
+      const { guid, version, filepath } =
+        await this.directoryController.splitUri(document.uri);
       const selection = editor.selections[0];
       const endCharacter = document.lineAt(selection.end).text.length;
       const range = RangeHelper.fromSelection(selection, endCharacter);
-      return this.createLink(guid, version, filepath,  RangeHelper.toString(range));
+      return this.createLink(
+        guid,
+        version,
+        filepath,
+        RangeHelper.toString(range)
+      );
     } else {
       throw new Error("No active text editor found.");
     }
@@ -143,7 +147,12 @@ export class CommentController {
     return this.createLink(guid, version, filepath, range);
   }
 
-  private createLink(guid: string, version: string, filepath: string, range: string){
+  private createLink(
+    guid: string,
+    version: string,
+    filepath: string,
+    range: string
+  ) {
     const link = `vscode://mozilla.assay/review/${guid}/${version}?path=${filepath}${range}`;
     vscode.env.clipboard.writeText(link);
     vscode.window.showInformationMessage("Link copied to clipboard.");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -261,6 +261,12 @@ export async function activate(context: vscode.ExtensionContext) {
     commentController
   );
 
+  const copyLinkFromContextDisposable = vscode.commands.registerCommand(
+    "assay.copyLinkFromContext",
+    commentController.copyLinkFromContext,
+    commentController
+  );
+
   const disposeCommentDisposable = vscode.commands.registerCommand(
     "assay.disposeComment",
     commentController.dispose,
@@ -277,6 +283,7 @@ export async function activate(context: vscode.ExtensionContext) {
     exportCommentDisposable,
     disposeCommentDisposable,
     copyLinkFromThreadDisposable,
+    copyLinkFromContextDisposable,
     deleteCommentsFolderDisposable,
     clearLintDisposable,
     addDirtyOnDeleteDisposable,

--- a/test/suite/controller/commentController.test.ts
+++ b/test/suite/controller/commentController.test.ts
@@ -140,6 +140,32 @@ describe("CommentController.ts", () => {
     });
   });
 
+  describe("copyLinkFromContext()", () => {
+    it("should copy the correctly formatted link to clipboard and show the info message", async () => {
+      sinon.stub(vscode.window, "activeTextEditor").value({
+        document: {
+          uri: cmt.uri,
+          lineAt: sinon.stub().returns({ text: "Code Line" }),
+        },
+        selections: [rng],
+      });
+      const cmtController = new CommentController(
+        "assay-tester",
+        "Assay Tester",
+        commentCacheControllerStub,
+        directoryControllerStub
+      );
+      const expectedLink = `vscode://mozilla.assay/review/guid/version?path=filepath#L1`;
+      const showInformationMessageStub = sinon.stub(
+        vscode.window,
+        "showInformationMessage"
+      );
+      const link = await cmtController.copyLinkFromContext();
+      expect(showInformationMessageStub.calledOnce).to.be.true;
+      expect(link).to.equal(expectedLink);
+    });
+  });
+
   describe("copyLinkFromThread", () => {
     it("should copy the correctly formatted link to clipboard and show the info message", async () => {
       const cmtController = new CommentController(


### PR DESCRIPTION
Closes #125.

**Changes**
- Adds a context menu button for copying a link to a certain line.

![image](https://github.com/user-attachments/assets/654aba3a-e1ad-49fa-94a2-bd53a1f1b3e8)
